### PR TITLE
Add support for popups and subsurfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/third_party/flutter_engine/debug/*.so
+/third_party/flutter_engine/profile/*.so
+/third_party/flutter_engine/release/*.so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,20 +26,23 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64529721f27c2314ced0890ce45e469574a73e5e6fdd6e9da1860eb29285f5e0"
+checksum = "052ad56e336bcc615a214bffbeca6c181ee9550acec193f0327e0b103b033a4d"
 dependencies = [
  "android-properties",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cc",
+ "cesu8",
+ "jni",
  "jni-sys",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-sys",
- "num_enum 0.6.1",
+ "num_enum",
+ "thiserror",
 ]
 
 [[package]]
@@ -51,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5f312b0a56c5cdf967c0aeb67f6289603354951683bc97ddc595ab974ba9aa"
+
+[[package]]
 name = "ash"
 version = "0.37.3+1.3.251"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +80,12 @@ checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -84,7 +112,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.38",
+ "syn",
  "which",
 ]
 
@@ -102,21 +130,21 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-sys"
-version = "0.1.0-beta.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
+checksum = "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92"
 dependencies = [
  "objc-sys",
 ]
 
 [[package]]
 name = "block2"
-version = "0.2.0-alpha.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
+checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
 dependencies = [
  "block-sys",
- "objc2-encode",
+ "objc2",
 ]
 
 [[package]]
@@ -142,28 +170,20 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
-name = "calloop"
-version = "0.10.6"
+name = "bytes"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8"
-dependencies = [
- "bitflags 1.3.2",
- "log",
- "nix 0.25.1",
- "slotmap",
- "thiserror",
- "vec_map",
-]
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "calloop"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadd183e815348c0649051b1c43418643208f8ed13c8a84da7215b4e1cf42714"
+checksum = "7b50b5a44d59a98c55a9eeb518f39bf7499ba19fd98ee7d22618687f3f10adbf"
 dependencies = [
  "bitflags 2.4.0",
  "log",
@@ -171,6 +191,18 @@ dependencies = [
  "rustix",
  "slab",
  "thiserror",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+dependencies = [
+ "calloop",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -182,6 +214,12 @@ dependencies = [
  "jobserver",
  "libc",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -226,6 +264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +300,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -374,23 +422,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -401,18 +438,30 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "gbm"
@@ -498,6 +547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "icrate"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
+dependencies = [
+ "block2",
+ "dispatch",
+ "objc2",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,18 +610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +631,22 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "jni-sys"
@@ -711,29 +775,20 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -761,27 +816,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "mio"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ndk"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "jni-sys",
+ "log",
  "ndk-sys",
- "num_enum 0.5.11",
+ "num_enum",
  "raw-window-handle",
  "thiserror",
 ]
@@ -794,36 +838,11 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.4.1+23.1.7779620"
+version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -848,7 +867,6 @@ dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
  "libc",
- "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -882,71 +900,46 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
 dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
+ "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
 name = "objc-sys"
-version = "0.2.0-beta.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
+checksum = "99e1d07c6eab1ce8b6382b8e3c7246fe117ff3f8b34be065f5ebace6749fe845"
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.3.patch-leaks.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
- "block2",
  "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0-pre.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
-dependencies = [
- "objc-sys",
-]
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "once_cell"
@@ -1026,7 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -1064,7 +1057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb156a45b6b9fe8027497422179fb65afc84d36707a7ca98297bf06bccb8d43f"
 dependencies = [
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -1117,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "redox_syscall"
@@ -1182,9 +1175,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1198,6 +1191,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scan_fmt"
@@ -1234,7 +1236,7 @@ checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -1273,15 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slotmap"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,12 +1283,12 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay?rev=4e41ab0#4e41ab0694c1c43324cc217dcf2a203cd240c0dc"
+source = "git+https://github.com/Smithay/smithay?rev=a8f3c46#a8f3c46f0bd0153160a3ba117502ba47c38ab0dc"
 dependencies = [
  "appendlist",
  "ash",
  "bitflags 2.4.0",
- "calloop 0.12.2",
+ "calloop",
  "cc",
  "cgmath",
  "cursor-icon",
@@ -1304,6 +1297,7 @@ dependencies = [
  "drm-ffi",
  "drm-fourcc",
  "encoding_rs",
+ "errno",
  "gbm",
  "gl_generator",
  "indexmap",
@@ -1317,6 +1311,7 @@ dependencies = [
  "pkg-config",
  "profiling",
  "rand",
+ "rustix",
  "scan_fmt",
  "scopeguard",
  "smallvec",
@@ -1326,11 +1321,11 @@ dependencies = [
  "udev 0.8.0",
  "wayland-backend",
  "wayland-egl",
- "wayland-protocols 0.31.0",
+ "wayland-protocols",
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-server",
- "wayland-sys 0.31.1",
+ "wayland-sys",
  "winit",
  "x11rb",
  "xkbcommon",
@@ -1338,21 +1333,27 @@ dependencies = [
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
+checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
 dependencies = [
- "bitflags 1.3.2",
- "calloop 0.10.6",
- "dlib",
- "lazy_static",
+ "bitflags 2.4.0",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
  "log",
- "memmap2 0.5.10",
- "nix 0.24.3",
- "pkg-config",
+ "memmap2 0.9.0",
+ "rustix",
+ "thiserror",
+ "wayland-backend",
  "wayland-client",
+ "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.29.5",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
 ]
 
 [[package]]
@@ -1365,14 +1366,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.109"
+name = "smol_str"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "serde",
 ]
 
 [[package]]
@@ -1416,7 +1415,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -1466,7 +1465,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -1538,16 +1537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1564,6 +1563,7 @@ dependencies = [
  "lazy_static",
  "log",
  "profiling",
+ "rustix",
  "serde",
  "serde_json",
  "smithay",
@@ -1572,6 +1572,16 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xcursor",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1601,8 +1611,20 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1623,7 +1645,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1645,44 +1667,39 @@ dependencies = [
  "nix 0.26.4",
  "scoped-tls",
  "smallvec",
- "wayland-sys 0.31.1",
+ "wayland-sys",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.29.5"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
+checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
 dependencies = [
- "bitflags 1.3.2",
- "downcast-rs",
- "libc",
- "nix 0.24.3",
- "scoped-tls",
- "wayland-commons",
- "wayland-scanner 0.29.5",
- "wayland-sys 0.29.5",
+ "bitflags 2.4.0",
+ "nix 0.26.4",
+ "wayland-backend",
+ "wayland-scanner",
 ]
 
 [[package]]
-name = "wayland-commons"
-version = "0.29.5"
+name = "wayland-csd-frame"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "nix 0.24.3",
- "once_cell",
- "smallvec",
- "wayland-sys 0.29.5",
+ "bitflags 2.4.0",
+ "cursor-icon",
+ "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
+checksum = "a44aa20ae986659d6c77d64d808a046996a932aa763913864dc40c359ef7ad5b"
 dependencies = [
- "nix 0.24.3",
+ "nix 0.26.4",
  "wayland-client",
  "xcursor",
 ]
@@ -1694,19 +1711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355f652e5a24ae02d2ad536c8fc2d3dcc6c2bd635027cd6103a193e7d75eeda2"
 dependencies = [
  "wayland-backend",
- "wayland-sys 0.31.1",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
-dependencies = [
- "bitflags 1.3.2",
- "wayland-client",
- "wayland-commons",
- "wayland-scanner 0.29.5",
+ "wayland-sys",
 ]
 
 [[package]]
@@ -1717,7 +1722,8 @@ checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
 dependencies = [
  "bitflags 2.4.0",
  "wayland-backend",
- "wayland-scanner 0.31.0",
+ "wayland-client",
+ "wayland-scanner",
  "wayland-server",
 ]
 
@@ -1729,9 +1735,22 @@ checksum = "bfa5933740b200188c9b4c38601b8212e8c154d7de0d2cb171944e137a77de1e"
 dependencies = [
  "bitflags 2.4.0",
  "wayland-backend",
- "wayland-protocols 0.31.0",
- "wayland-scanner 0.31.0",
+ "wayland-protocols",
+ "wayland-scanner",
  "wayland-server",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+dependencies = [
+ "bitflags 2.4.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
 ]
 
 [[package]]
@@ -1742,20 +1761,10 @@ checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
  "bitflags 2.4.0",
  "wayland-backend",
- "wayland-protocols 0.31.0",
- "wayland-scanner 0.31.0",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
  "wayland-server",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
-dependencies = [
- "proc-macro2",
- "quote",
- "xml-rs",
 ]
 
 [[package]]
@@ -1780,18 +1789,7 @@ dependencies = [
  "io-lifetimes 2.0.2",
  "nix 0.26.4",
  "wayland-backend",
- "wayland-scanner 0.31.0",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
-dependencies = [
- "dlib",
- "lazy_static",
- "pkg-config",
+ "wayland-scanner",
 ]
 
 [[package]]
@@ -1804,6 +1802,7 @@ dependencies = [
  "libc",
  "log",
  "memoffset 0.9.0",
+ "once_cell",
  "pkg-config",
 ]
 
@@ -1812,6 +1811,16 @@ name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1844,6 +1853,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-wsapoll"
@@ -1994,36 +2012,49 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winit"
-version = "0.28.7"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
+checksum = "161598019a9da35ab6c34dc46cd13546cba9dbf9816475d4dd9a639455016563"
 dependencies = [
+ "ahash",
  "android-activity",
- "bitflags 1.3.2",
+ "atomic-waker",
+ "bitflags 2.4.0",
+ "bytemuck",
+ "calloop",
  "cfg_aliases",
  "core-foundation",
  "core-graphics",
- "dispatch",
- "instant",
+ "cursor-icon",
+ "icrate",
+ "js-sys",
  "libc",
  "log",
- "mio",
+ "memmap2 0.9.0",
  "ndk",
+ "ndk-sys",
  "objc2",
  "once_cell",
  "orbclient",
  "percent-encoding",
  "raw-window-handle",
  "redox_syscall",
+ "rustix",
  "smithay-client-toolkit",
+ "smol_str",
+ "unicode-segmentation",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
  "wayland-client",
- "wayland-commons",
- "wayland-protocols 0.29.5",
- "wayland-scanner 0.29.5",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
  "web-sys",
- "windows-sys 0.45.0",
+ "web-time",
+ "windows-sys 0.48.0",
  "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
 ]
 
 [[package]]
@@ -2052,8 +2083,12 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
+ "libc",
+ "libloading 0.7.4",
  "nix 0.26.4",
+ "once_cell",
  "winapi",
  "winapi-wsapoll",
  "x11rb-protocol",
@@ -2079,12 +2114,25 @@ dependencies = [
 
 [[package]]
 name = "xkbcommon"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c286371c44b3572d19b09196c129a8fff47d7704d6494daefb44fec10f0278ab"
+checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
 dependencies = [
  "libc",
- "memmap2 0.7.1",
+ "memmap2 0.8.0",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
+dependencies = [
+ "bitflags 2.4.0",
+ "dlib",
+ "log",
+ "once_cell",
  "xkeysym",
 ]
 
@@ -2099,3 +2147,23 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ members = [
 ]
 
 [dependencies]
-smithay = { git = "https://github.com/Smithay/smithay", rev = "4e41ab0", features = ["default", "wayland_frontend", "backend_egl", "use_system_lib"] }
+smithay = { git = "https://github.com/Smithay/smithay", rev = "a8f3c46", features = ["default", "wayland_frontend", "backend_egl", "use_system_lib"] }
 smithay-drm-extras = {path = "third_party/smithay-drm-extras" }
+rustix = "0.38.21"
 input-linux = "0.6.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 log = "0.4.20"

--- a/src/flutter_engine/callbacks.rs
+++ b/src/flutter_engine/callbacks.rs
@@ -137,8 +137,8 @@ pub unsafe extern "C" fn platform_message_callback(message: *const FlutterPlatfo
 pub unsafe extern "C" fn gl_external_texture_frame_callback(
     user_data: *mut c_void,
     texture_id: i64,
-    width: usize,
-    height: usize,
+    _width: usize,
+    _height: usize,
     texture_out: *mut FlutterOpenGLTexture,
 ) -> bool {
     let flutter_engine = &mut *(user_data as *mut FlutterEngine);
@@ -148,22 +148,20 @@ pub unsafe extern "C" fn gl_external_texture_frame_callback(
         channels.rx_external_texture_name.recv().ok()
     }).unwrap_or((0, ffi::RGBA8));
 
-    unsafe {
-        // std::ptr::addr_of_mut!(*texture_out).write(FlutterOpenGLTexture {
-            std::ptr::addr_of_mut!((*texture_out).target).write(ffi::TEXTURE_2D);
-            std::ptr::addr_of_mut!((*texture_out).name).write(dbg!(texture_name));
-            std::ptr::addr_of_mut!((*texture_out).format).write(ffi::RGBA8);
-            std::ptr::addr_of_mut!((*texture_out).user_data).write(null_mut());
-            std::ptr::addr_of_mut!((*texture_out).destruction_callback).write(None);
-            std::ptr::addr_of_mut!((*texture_out).width).write(0);
-            std::ptr::addr_of_mut!((*texture_out).height).write(0);
-            // name: dbg!(texture_name),
-            // format,
-            // user_data: null_mut(),
-            // destruction_callback: None,
-            // width: 0,
-            // height: 0,
-        // });
-    }
+    let texture_out = &mut *texture_out;
+
+    // TODO: Don't hardcode the target.
+    // If the texture is imported from a DMABUF, I think it the target should be GL_TEXTURE_EXTERNAL_OES.
+    texture_out.target = ffi::TEXTURE_2D;
+    texture_out.name = texture_name;
+    // TODO: Should probably not hardcode the format in case the texture is not RGBA8.
+    // I can't just assign the format obtained from the channel because it's BGRA_EXT and for some
+    // reason it doesn't work while RGBA8 does.
+    texture_out.format = ffi::RGBA8;
+    texture_out.user_data = null_mut();
+    texture_out.destruction_callback = None;
+    texture_out.width = 0;
+    texture_out.height = 0;
+
     texture_name != 0
 }

--- a/src/flutter_engine/platform_channels.rs
+++ b/src/flutter_engine/platform_channels.rs
@@ -1,6 +1,5 @@
 pub mod binary_messenger;
 pub mod binary_messenger_impl;
-
 pub mod method_call;
 pub mod encodable_value;
 pub mod method_result;

--- a/src/flutter_engine/wayland_messages.rs
+++ b/src/flutter_engine/wayland_messages.rs
@@ -1,10 +1,11 @@
 use smithay::utils::{Buffer as BufferCoords, Logical, Point, Rectangle, Size};
 use smithay::wayland::compositor;
-use smithay::wayland::compositor::RegionAttributes;
+use smithay::wayland::compositor::{RectangleKind, RegionAttributes};
 use smithay::wayland::shell::xdg;
 
 use crate::flutter_engine::platform_channels::encodable_value::EncodableValue;
 
+#[derive(Debug)]
 pub struct SurfaceCommitMessage {
     pub view_id: u64,
     pub role: Option<&'static str>,
@@ -14,16 +15,49 @@ pub struct SurfaceCommitMessage {
     pub scale: i32,
     pub input_region: Option<RegionAttributes>,
     pub xdg_surface: Option<XdgSurfaceCommitMessage>,
+    pub xdg_popup: Option<XdgPopupCommitMessage>,
+    pub subsurface: Option<SubsurfaceCommitMessage>,
+    pub subsurfaces_below: Vec<u64>,
+    pub subsurfaces_above: Vec<u64>,
 }
 
+#[derive(Debug)]
 pub struct XdgSurfaceCommitMessage {
-    pub mapped: bool,
     pub role: Option<&'static str>,
     pub geometry: Option<Rectangle<i32, Logical>>,
 }
 
+#[derive(Debug)]
+pub struct XdgPopupCommitMessage {
+    pub parent_id: u64,
+    pub geometry: Rectangle<i32, Logical>,
+}
+
+#[derive(Debug)]
+pub struct SubsurfaceCommitMessage {
+    pub location: Point<i32, Logical>,
+}
+
 impl SurfaceCommitMessage {
     pub fn serialize(self) -> EncodableValue {
+        // TODO: Serialize all the rectangles instead of merging them into one.
+        let input_region = if let Some(input_region) = self.input_region {
+            let mut acc: Option<Rectangle<i32, Logical>> = None;
+            for (kind, rect) in input_region.rects {
+                if let RectangleKind::Add = kind {
+                    if let Some(acc_) = acc {
+                        acc = Some(acc_.merge(rect));
+                    } else {
+                        acc = Some(rect);
+                    }
+                }
+            }
+            acc.unwrap_or_default()
+        } else {
+            // TODO: Account for DPI scaling.
+            self.buffer_size.map(|size| Rectangle::from_loc_and_size((0, 0), (size.w, size.h))).unwrap_or_default()
+        };
+
         let mut vec = vec![
             (EncodableValue::String("view_id".to_string()), EncodableValue::Int64(self.view_id as i64)),
             (EncodableValue::String("surface".to_string()), EncodableValue::Map(vec![
@@ -34,33 +68,53 @@ impl SurfaceCommitMessage {
                         _ => 0,
                     }
                 }).unwrap_or(0))),
-                (EncodableValue::String("textureId".to_string()), EncodableValue::Int64(self.texture_id as i64)),
-                (EncodableValue::String("x".to_string()), EncodableValue::Int32(self.buffer_delta.map(|delta| delta.x).unwrap_or(0))),
-                (EncodableValue::String("y".to_string()), EncodableValue::Int32(self.buffer_delta.map(|delta| delta.y).unwrap_or(0))),
+                (EncodableValue::String("textureId".to_string()), EncodableValue::Int64(self.texture_id)),
+                (EncodableValue::String("x".to_string()), EncodableValue::Int32(0)),
+                (EncodableValue::String("y".to_string()), EncodableValue::Int32(0)),
                 (EncodableValue::String("width".to_string()), EncodableValue::Int32(self.buffer_size.map(|size| size.w).unwrap_or(0))),
                 (EncodableValue::String("height".to_string()), EncodableValue::Int32(self.buffer_size.map(|size| size.h).unwrap_or(0))),
                 (EncodableValue::String("scale".to_string()), EncodableValue::Int32(self.scale)),
-                (EncodableValue::String("subsurfaces_below".to_string()), EncodableValue::List(vec![])),
-                (EncodableValue::String("subsurfaces_above".to_string()), EncodableValue::List(vec![])),
+                (EncodableValue::String("subsurfaces_below".to_string()), EncodableValue::List(self.subsurfaces_below.into_iter().map(|id| EncodableValue::Int64(id as i64)).collect())),
+                (EncodableValue::String("subsurfaces_above".to_string()), EncodableValue::List(self.subsurfaces_above.into_iter().map(|id| EncodableValue::Int64(id as i64)).collect())),
                 (EncodableValue::String("input_region".to_string()), EncodableValue::Map(vec![
-                    // TODO
-                    (EncodableValue::String("x1".to_string()), EncodableValue::Int64(self.buffer_delta.map(|delta| delta.x).unwrap_or(0) as i64)),
-                    (EncodableValue::String("y1".to_string()), EncodableValue::Int64(self.buffer_delta.map(|delta| delta.y).unwrap_or(0) as i64)),
-                    (EncodableValue::String("x2".to_string()), EncodableValue::Int64(self.buffer_size.map(|size| size.w).unwrap_or(0) as i64)),
-                    (EncodableValue::String("y2".to_string()), EncodableValue::Int64(self.buffer_size.map(|size| size.h).unwrap_or(0) as i64)),
+                    (EncodableValue::String("x1".to_string()), EncodableValue::Int32(input_region.loc.x)),
+                    (EncodableValue::String("y1".to_string()), EncodableValue::Int32(input_region.loc.y)),
+                    (EncodableValue::String("x2".to_string()), EncodableValue::Int32(input_region.loc.x + input_region.size.w)),
+                    (EncodableValue::String("y2".to_string()), EncodableValue::Int32(input_region.loc.y + input_region.size.h)),
                 ])),
             ])),
         ];
+
+        if let Some(subsurface) = self.subsurface {
+            vec.extend([
+                (EncodableValue::String("has_subsurface".to_string()), EncodableValue::Bool(true)),
+                (EncodableValue::String("subsurface".to_string()), subsurface.serialize()),
+            ]);
+        } else {
+            vec.push(
+                (EncodableValue::String("has_subsurface".to_string()), EncodableValue::Bool(false)),
+            );
+        }
 
         if let Some(xdg_surface) = self.xdg_surface {
             vec.extend([
                 (EncodableValue::String("has_xdg_surface".to_string()), EncodableValue::Bool(true)),
                 (EncodableValue::String("xdg_surface".to_string()), xdg_surface.serialize()),
-                (EncodableValue::String("has_xdg_popup".to_string()), EncodableValue::Bool(false)),
                 (EncodableValue::String("has_toplevel_decoration".to_string()), EncodableValue::Bool(false)),
                 (EncodableValue::String("has_toplevel_title".to_string()), EncodableValue::Bool(false)),
                 (EncodableValue::String("has_toplevel_app_id".to_string()), EncodableValue::Bool(false)),
             ]);
+
+            if let Some(xdg_popup) = self.xdg_popup {
+                vec.extend([
+                    (EncodableValue::String("has_xdg_popup".to_string()), EncodableValue::Bool(true)),
+                    (EncodableValue::String("xdg_popup".to_string()), xdg_popup.serialize()),
+                ]);
+            } else {
+                vec.push(
+                    (EncodableValue::String("has_xdg_popup".to_string()), EncodableValue::Bool(false)),
+                );
+            }
         } else {
             vec.push(
                 (EncodableValue::String("has_xdg_surface".to_string()), EncodableValue::Bool(false)),
@@ -74,7 +128,6 @@ impl SurfaceCommitMessage {
 impl XdgSurfaceCommitMessage {
     pub fn serialize(self) -> EncodableValue {
         EncodableValue::Map(vec![
-            (EncodableValue::String("mapped".to_string()), EncodableValue::Bool(self.mapped)),
             (EncodableValue::String("role".to_string()), EncodableValue::Int64(self.role.map(|role| {
                 match role {
                     xdg::XDG_TOPLEVEL_ROLE => 1,
@@ -86,6 +139,27 @@ impl XdgSurfaceCommitMessage {
             (EncodableValue::String("y".to_string()), EncodableValue::Int64(self.geometry.map(|geometry| geometry.loc.y).unwrap_or(0) as i64)),
             (EncodableValue::String("width".to_string()), EncodableValue::Int64(self.geometry.map(|geometry| geometry.size.w).unwrap_or(0) as i64)),
             (EncodableValue::String("height".to_string()), EncodableValue::Int64(self.geometry.map(|geometry| geometry.size.h).unwrap_or(0) as i64)),
+        ])
+    }
+}
+
+impl XdgPopupCommitMessage {
+    pub fn serialize(self) -> EncodableValue {
+        EncodableValue::Map(vec![
+            (EncodableValue::String("parent_id".to_string()), EncodableValue::Int64(self.parent_id as i64)),
+            (EncodableValue::String("x".to_string()), EncodableValue::Int64(self.geometry.loc.x as i64)),
+            (EncodableValue::String("y".to_string()), EncodableValue::Int64(self.geometry.loc.y as i64)),
+            (EncodableValue::String("width".to_string()), EncodableValue::Int64(self.geometry.size.w as i64)),
+            (EncodableValue::String("height".to_string()), EncodableValue::Int64(self.geometry.size.h as i64)),
+        ])
+    }
+}
+
+impl SubsurfaceCommitMessage {
+    pub fn serialize(self) -> EncodableValue {
+        EncodableValue::Map(vec![
+            (EncodableValue::String("x".to_string()), EncodableValue::Int64(self.location.x as i64)),
+            (EncodableValue::String("y".to_string()), EncodableValue::Int64(self.location.y as i64)),
         ])
     }
 }

--- a/veshell_flutter/lib/generated/dbus/dbus.g.dart
+++ b/veshell_flutter/lib/generated/dbus/dbus.g.dart
@@ -21,4 +21,5 @@ final dbusSystemBusProvider = Provider<DBusClient>.internal(
 );
 
 typedef DbusSystemBusRef = ProviderRef<DBusClient>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/platform_api.g.dart
+++ b/veshell_flutter/lib/generated/platform_api.g.dart
@@ -30,8 +30,6 @@ class _SystemHash {
   }
 }
 
-typedef _TextInputEventStreamByIdRef = StreamProviderRef<dynamic>;
-
 /// See also [_textInputEventStreamById].
 @ProviderFor(_textInputEventStreamById)
 const _textInputEventStreamByIdProvider = _TextInputEventStreamByIdFamily();
@@ -78,10 +76,10 @@ class _TextInputEventStreamByIdFamily extends Family<AsyncValue<dynamic>> {
 class _TextInputEventStreamByIdProvider extends StreamProvider<dynamic> {
   /// See also [_textInputEventStreamById].
   _TextInputEventStreamByIdProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => _textInputEventStreamById(
-            ref,
+            ref as _TextInputEventStreamByIdRef,
             viewId,
           ),
           from: _textInputEventStreamByIdProvider,
@@ -93,9 +91,43 @@ class _TextInputEventStreamByIdProvider extends StreamProvider<dynamic> {
           dependencies: _TextInputEventStreamByIdFamily._dependencies,
           allTransitiveDependencies:
               _TextInputEventStreamByIdFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  _TextInputEventStreamByIdProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    Stream<dynamic> Function(_TextInputEventStreamByIdRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: _TextInputEventStreamByIdProvider._internal(
+        (ref) => create(ref as _TextInputEventStreamByIdRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  StreamProviderElement<dynamic> createElement() {
+    return _TextInputEventStreamByIdProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -111,9 +143,21 @@ class _TextInputEventStreamByIdProvider extends StreamProvider<dynamic> {
   }
 }
 
+mixin _TextInputEventStreamByIdRef on StreamProviderRef<dynamic> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _TextInputEventStreamByIdProviderElement
+    extends StreamProviderElement<dynamic> with _TextInputEventStreamByIdRef {
+  _TextInputEventStreamByIdProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as _TextInputEventStreamByIdProvider).viewId;
+}
+
 String _$textInputEventStreamHash() =>
     r'a1c50514a750715c755720256bb540d7649ddc1a';
-typedef TextInputEventStreamRef = FutureProviderRef<TextInputEventType>;
 
 /// See also [textInputEventStream].
 @ProviderFor(textInputEventStream)
@@ -162,10 +206,10 @@ class TextInputEventStreamFamily
 class TextInputEventStreamProvider extends FutureProvider<TextInputEventType> {
   /// See also [textInputEventStream].
   TextInputEventStreamProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => textInputEventStream(
-            ref,
+            ref as TextInputEventStreamRef,
             viewId,
           ),
           from: textInputEventStreamProvider,
@@ -177,9 +221,44 @@ class TextInputEventStreamProvider extends FutureProvider<TextInputEventType> {
           dependencies: TextInputEventStreamFamily._dependencies,
           allTransitiveDependencies:
               TextInputEventStreamFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  TextInputEventStreamProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    FutureOr<TextInputEventType> Function(TextInputEventStreamRef provider)
+        create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: TextInputEventStreamProvider._internal(
+        (ref) => create(ref as TextInputEventStreamRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  FutureProviderElement<TextInputEventType> createElement() {
+    return _TextInputEventStreamProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -193,6 +272,20 @@ class TextInputEventStreamProvider extends FutureProvider<TextInputEventType> {
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin TextInputEventStreamRef on FutureProviderRef<TextInputEventType> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _TextInputEventStreamProviderElement
+    extends FutureProviderElement<TextInputEventType>
+    with TextInputEventStreamRef {
+  _TextInputEventStreamProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as TextInputEventStreamProvider).viewId;
 }
 
 String _$windowMappedStreamHash() =>
@@ -229,7 +322,7 @@ final windowUnmappedStreamProvider =
 );
 
 typedef _$WindowUnmappedStream = StreamNotifier<int>;
-String _$platformApiHash() => r'4bbfd717c0a2bbb9c36fc8a95da5442bc7355168';
+String _$platformApiHash() => r'f89b772c12337ae88bc05dbf6d7807c3e05efbd1';
 
 /// See also [PlatformApi].
 @ProviderFor(PlatformApi)
@@ -244,4 +337,5 @@ final platformApiProvider =
 );
 
 typedef _$PlatformApi = Notifier<PlatformApiState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/popup_stack.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/popup_stack.g.dart
@@ -11,8 +11,7 @@ String _$popupStackGlobalKeyHash() =>
 
 /// See also [popupStackGlobalKey].
 @ProviderFor(popupStackGlobalKey)
-final popupStackGlobalKeyProvider =
-    Provider<GlobalKey<State<StatefulWidget>>>.internal(
+final popupStackGlobalKeyProvider = Provider<GlobalKey>.internal(
   popupStackGlobalKey,
   name: r'popupStackGlobalKeyProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -22,7 +21,7 @@ final popupStackGlobalKeyProvider =
   allTransitiveDependencies: null,
 );
 
-typedef PopupStackGlobalKeyRef = ProviderRef<GlobalKey<State<StatefulWidget>>>;
+typedef PopupStackGlobalKeyRef = ProviderRef<GlobalKey>;
 String _$popupStackChildrenHash() =>
     r'03c8602175bf1c73be917deeccf3a38071b935a0';
 
@@ -40,4 +39,5 @@ final popupStackChildrenProvider =
 );
 
 typedef _$PopupStackChildren = Notifier<IList<int>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/app_drawer.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/app_drawer.g.dart
@@ -40,4 +40,5 @@ final appDrawerFilterProvider =
 );
 
 typedef _$AppDrawerFilter = Notifier<String>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/desktop_entries.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/desktop_entries.g.dart
@@ -97,8 +97,6 @@ class _SystemHash {
   }
 }
 
-typedef IconRef = FutureProviderRef<File?>;
-
 /// See also [icon].
 @ProviderFor(icon)
 const iconProvider = IconFamily();
@@ -145,10 +143,10 @@ class IconFamily extends Family<AsyncValue<File?>> {
 class IconProvider extends FutureProvider<File?> {
   /// See also [icon].
   IconProvider(
-    this.query,
-  ) : super.internal(
+    IconQuery query,
+  ) : this._internal(
           (ref) => icon(
-            ref,
+            ref as IconRef,
             query,
           ),
           from: iconProvider,
@@ -157,9 +155,43 @@ class IconProvider extends FutureProvider<File?> {
               const bool.fromEnvironment('dart.vm.product') ? null : _$iconHash,
           dependencies: IconFamily._dependencies,
           allTransitiveDependencies: IconFamily._allTransitiveDependencies,
+          query: query,
         );
 
+  IconProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.query,
+  }) : super.internal();
+
   final IconQuery query;
+
+  @override
+  Override overrideWith(
+    FutureOr<File?> Function(IconRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: IconProvider._internal(
+        (ref) => create(ref as IconRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        query: query,
+      ),
+    );
+  }
+
+  @override
+  FutureProviderElement<File?> createElement() {
+    return _IconProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -175,9 +207,20 @@ class IconProvider extends FutureProvider<File?> {
   }
 }
 
+mixin IconRef on FutureProviderRef<File?> {
+  /// The parameter `query` of this provider.
+  IconQuery get query;
+}
+
+class _IconProviderElement extends FutureProviderElement<File?> with IconRef {
+  _IconProviderElement(super.provider);
+
+  @override
+  IconQuery get query => (origin as IconProvider).query;
+}
+
 String _$fileToScalableImageHash() =>
     r'cdee05cbedc6229524232afe652f39fafdb7da6f';
-typedef FileToScalableImageRef = FutureProviderRef<ScalableImage>;
 
 /// See also [fileToScalableImage].
 @ProviderFor(fileToScalableImage)
@@ -225,10 +268,10 @@ class FileToScalableImageFamily extends Family<AsyncValue<ScalableImage>> {
 class FileToScalableImageProvider extends FutureProvider<ScalableImage> {
   /// See also [fileToScalableImage].
   FileToScalableImageProvider(
-    this.path,
-  ) : super.internal(
+    String path,
+  ) : this._internal(
           (ref) => fileToScalableImage(
-            ref,
+            ref as FileToScalableImageRef,
             path,
           ),
           from: fileToScalableImageProvider,
@@ -240,9 +283,43 @@ class FileToScalableImageProvider extends FutureProvider<ScalableImage> {
           dependencies: FileToScalableImageFamily._dependencies,
           allTransitiveDependencies:
               FileToScalableImageFamily._allTransitiveDependencies,
+          path: path,
         );
 
+  FileToScalableImageProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.path,
+  }) : super.internal();
+
   final String path;
+
+  @override
+  Override overrideWith(
+    FutureOr<ScalableImage> Function(FileToScalableImageRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: FileToScalableImageProvider._internal(
+        (ref) => create(ref as FileToScalableImageRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        path: path,
+      ),
+    );
+  }
+
+  @override
+  FutureProviderElement<ScalableImage> createElement() {
+    return _FileToScalableImageProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -257,4 +334,18 @@ class FileToScalableImageProvider extends FutureProvider<ScalableImage> {
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+
+mixin FileToScalableImageRef on FutureProviderRef<ScalableImage> {
+  /// The parameter `path` of this provider.
+  String get path;
+}
+
+class _FileToScalableImageProviderElement
+    extends FutureProviderElement<ScalableImage> with FileToScalableImageRef {
+  _FileToScalableImageProviderElement(super.provider);
+
+  @override
+  String get path => (origin as FileToScalableImageProvider).path;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/subsurface_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/subsurface_state.freezed.dart
@@ -16,9 +16,10 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$SubsurfaceState {
+  bool get mapped => throw _privateConstructorUsedError;
+  int get parent => throw _privateConstructorUsedError;
   Offset get position =>
       throw _privateConstructorUsedError; // relative to the parent
-  bool get mapped => throw _privateConstructorUsedError;
   Key get widgetKey => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -32,7 +33,7 @@ abstract class $SubsurfaceStateCopyWith<$Res> {
           SubsurfaceState value, $Res Function(SubsurfaceState) then) =
       _$SubsurfaceStateCopyWithImpl<$Res, SubsurfaceState>;
   @useResult
-  $Res call({Offset position, bool mapped, Key widgetKey});
+  $Res call({bool mapped, int parent, Offset position, Key widgetKey});
 }
 
 /// @nodoc
@@ -48,19 +49,24 @@ class _$SubsurfaceStateCopyWithImpl<$Res, $Val extends SubsurfaceState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? position = null,
     Object? mapped = null,
+    Object? parent = null,
+    Object? position = null,
     Object? widgetKey = null,
   }) {
     return _then(_value.copyWith(
-      position: null == position
-          ? _value.position
-          : position // ignore: cast_nullable_to_non_nullable
-              as Offset,
       mapped: null == mapped
           ? _value.mapped
           : mapped // ignore: cast_nullable_to_non_nullable
               as bool,
+      parent: null == parent
+          ? _value.parent
+          : parent // ignore: cast_nullable_to_non_nullable
+              as int,
+      position: null == position
+          ? _value.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as Offset,
       widgetKey: null == widgetKey
           ? _value.widgetKey
           : widgetKey // ignore: cast_nullable_to_non_nullable
@@ -70,40 +76,45 @@ class _$SubsurfaceStateCopyWithImpl<$Res, $Val extends SubsurfaceState>
 }
 
 /// @nodoc
-abstract class _$$_SubsurfaceStateCopyWith<$Res>
+abstract class _$$SubsurfaceStateImplCopyWith<$Res>
     implements $SubsurfaceStateCopyWith<$Res> {
-  factory _$$_SubsurfaceStateCopyWith(
-          _$_SubsurfaceState value, $Res Function(_$_SubsurfaceState) then) =
-      __$$_SubsurfaceStateCopyWithImpl<$Res>;
+  factory _$$SubsurfaceStateImplCopyWith(_$SubsurfaceStateImpl value,
+          $Res Function(_$SubsurfaceStateImpl) then) =
+      __$$SubsurfaceStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({Offset position, bool mapped, Key widgetKey});
+  $Res call({bool mapped, int parent, Offset position, Key widgetKey});
 }
 
 /// @nodoc
-class __$$_SubsurfaceStateCopyWithImpl<$Res>
-    extends _$SubsurfaceStateCopyWithImpl<$Res, _$_SubsurfaceState>
-    implements _$$_SubsurfaceStateCopyWith<$Res> {
-  __$$_SubsurfaceStateCopyWithImpl(
-      _$_SubsurfaceState _value, $Res Function(_$_SubsurfaceState) _then)
+class __$$SubsurfaceStateImplCopyWithImpl<$Res>
+    extends _$SubsurfaceStateCopyWithImpl<$Res, _$SubsurfaceStateImpl>
+    implements _$$SubsurfaceStateImplCopyWith<$Res> {
+  __$$SubsurfaceStateImplCopyWithImpl(
+      _$SubsurfaceStateImpl _value, $Res Function(_$SubsurfaceStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? position = null,
     Object? mapped = null,
+    Object? parent = null,
+    Object? position = null,
     Object? widgetKey = null,
   }) {
-    return _then(_$_SubsurfaceState(
-      position: null == position
-          ? _value.position
-          : position // ignore: cast_nullable_to_non_nullable
-              as Offset,
+    return _then(_$SubsurfaceStateImpl(
       mapped: null == mapped
           ? _value.mapped
           : mapped // ignore: cast_nullable_to_non_nullable
               as bool,
+      parent: null == parent
+          ? _value.parent
+          : parent // ignore: cast_nullable_to_non_nullable
+              as int,
+      position: null == position
+          ? _value.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as Offset,
       widgetKey: null == widgetKey
           ? _value.widgetKey
           : widgetKey // ignore: cast_nullable_to_non_nullable
@@ -114,59 +125,70 @@ class __$$_SubsurfaceStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_SubsurfaceState implements _SubsurfaceState {
-  const _$_SubsurfaceState(
-      {required this.position, required this.mapped, required this.widgetKey});
+class _$SubsurfaceStateImpl implements _SubsurfaceState {
+  const _$SubsurfaceStateImpl(
+      {required this.mapped,
+      required this.parent,
+      required this.position,
+      required this.widgetKey});
 
+  @override
+  final bool mapped;
+  @override
+  final int parent;
   @override
   final Offset position;
 // relative to the parent
-  @override
-  final bool mapped;
   @override
   final Key widgetKey;
 
   @override
   String toString() {
-    return 'SubsurfaceState(position: $position, mapped: $mapped, widgetKey: $widgetKey)';
+    return 'SubsurfaceState(mapped: $mapped, parent: $parent, position: $position, widgetKey: $widgetKey)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SubsurfaceState &&
+            other is _$SubsurfaceStateImpl &&
+            (identical(other.mapped, mapped) || other.mapped == mapped) &&
+            (identical(other.parent, parent) || other.parent == parent) &&
             (identical(other.position, position) ||
                 other.position == position) &&
-            (identical(other.mapped, mapped) || other.mapped == mapped) &&
             (identical(other.widgetKey, widgetKey) ||
                 other.widgetKey == widgetKey));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, position, mapped, widgetKey);
+  int get hashCode =>
+      Object.hash(runtimeType, mapped, parent, position, widgetKey);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SubsurfaceStateCopyWith<_$_SubsurfaceState> get copyWith =>
-      __$$_SubsurfaceStateCopyWithImpl<_$_SubsurfaceState>(this, _$identity);
+  _$$SubsurfaceStateImplCopyWith<_$SubsurfaceStateImpl> get copyWith =>
+      __$$SubsurfaceStateImplCopyWithImpl<_$SubsurfaceStateImpl>(
+          this, _$identity);
 }
 
 abstract class _SubsurfaceState implements SubsurfaceState {
   const factory _SubsurfaceState(
-      {required final Offset position,
-      required final bool mapped,
-      required final Key widgetKey}) = _$_SubsurfaceState;
+      {required final bool mapped,
+      required final int parent,
+      required final Offset position,
+      required final Key widgetKey}) = _$SubsurfaceStateImpl;
 
+  @override
+  bool get mapped;
+  @override
+  int get parent;
   @override
   Offset get position;
   @override // relative to the parent
-  bool get mapped;
-  @override
   Key get widgetKey;
   @override
   @JsonKey(ignore: true)
-  _$$_SubsurfaceStateCopyWith<_$_SubsurfaceState> get copyWith =>
+  _$$SubsurfaceStateImplCopyWith<_$SubsurfaceStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/common/state/subsurface_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/subsurface_state.g.dart
@@ -29,8 +29,6 @@ class _SystemHash {
   }
 }
 
-typedef SubsurfaceWidgetRef = ProviderRef<Subsurface>;
-
 /// See also [subsurfaceWidget].
 @ProviderFor(subsurfaceWidget)
 const subsurfaceWidgetProvider = SubsurfaceWidgetFamily();
@@ -77,10 +75,10 @@ class SubsurfaceWidgetFamily extends Family<Subsurface> {
 class SubsurfaceWidgetProvider extends Provider<Subsurface> {
   /// See also [subsurfaceWidget].
   SubsurfaceWidgetProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => subsurfaceWidget(
-            ref,
+            ref as SubsurfaceWidgetRef,
             viewId,
           ),
           from: subsurfaceWidgetProvider,
@@ -92,9 +90,43 @@ class SubsurfaceWidgetProvider extends Provider<Subsurface> {
           dependencies: SubsurfaceWidgetFamily._dependencies,
           allTransitiveDependencies:
               SubsurfaceWidgetFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  SubsurfaceWidgetProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    Subsurface Function(SubsurfaceWidgetRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: SubsurfaceWidgetProvider._internal(
+        (ref) => create(ref as SubsurfaceWidgetRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<Subsurface> createElement() {
+    return _SubsurfaceWidgetProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -110,7 +142,20 @@ class SubsurfaceWidgetProvider extends Provider<Subsurface> {
   }
 }
 
-String _$subsurfaceStatesHash() => r'4f9acc62d958c409876790f543760795dd38c5dd';
+mixin SubsurfaceWidgetRef on ProviderRef<Subsurface> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _SubsurfaceWidgetProviderElement extends ProviderElement<Subsurface>
+    with SubsurfaceWidgetRef {
+  _SubsurfaceWidgetProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as SubsurfaceWidgetProvider).viewId;
+}
+
+String _$subsurfaceStatesHash() => r'30e609cd91a810f3477db020d3264d91d4d50686';
 
 abstract class _$SubsurfaceStates extends BuildlessNotifier<SubsurfaceState> {
   late final int viewId;
@@ -167,8 +212,8 @@ class SubsurfaceStatesProvider
     extends NotifierProviderImpl<SubsurfaceStates, SubsurfaceState> {
   /// See also [SubsurfaceStates].
   SubsurfaceStatesProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => SubsurfaceStates()..viewId = viewId,
           from: subsurfaceStatesProvider,
           name: r'subsurfaceStatesProvider',
@@ -179,9 +224,50 @@ class SubsurfaceStatesProvider
           dependencies: SubsurfaceStatesFamily._dependencies,
           allTransitiveDependencies:
               SubsurfaceStatesFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  SubsurfaceStatesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  SubsurfaceState runNotifierBuild(
+    covariant SubsurfaceStates notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(SubsurfaceStates Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: SubsurfaceStatesProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<SubsurfaceStates, SubsurfaceState> createElement() {
+    return _SubsurfaceStatesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -195,14 +281,20 @@ class SubsurfaceStatesProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin SubsurfaceStatesRef on NotifierProviderRef<SubsurfaceState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _SubsurfaceStatesProviderElement
+    extends NotifierProviderElement<SubsurfaceStates, SubsurfaceState>
+    with SubsurfaceStatesRef {
+  _SubsurfaceStatesProviderElement(super.provider);
 
   @override
-  SubsurfaceState runNotifierBuild(
-    covariant SubsurfaceStates notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as SubsurfaceStatesProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/surface_ids.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/surface_ids.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of '../../../../ui/common/state/surface_ids.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$surfaceIdsHash() => r'cb61014a5fa76443982c62a83b65e62b11537f7b';
+
+/// See also [SurfaceIds].
+@ProviderFor(SurfaceIds)
+final surfaceIdsProvider = NotifierProvider<SurfaceIds, ISet<int>>.internal(
+  SurfaceIds.new,
+  name: r'surfaceIdsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$surfaceIdsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$SurfaceIds = Notifier<ISet<int>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/surface_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/surface_state.freezed.dart
@@ -137,11 +137,11 @@ class _$SurfaceStateCopyWithImpl<$Res, $Val extends SurfaceState>
 }
 
 /// @nodoc
-abstract class _$$_SurfaceStateCopyWith<$Res>
+abstract class _$$SurfaceStateImplCopyWith<$Res>
     implements $SurfaceStateCopyWith<$Res> {
-  factory _$$_SurfaceStateCopyWith(
-          _$_SurfaceState value, $Res Function(_$_SurfaceState) then) =
-      __$$_SurfaceStateCopyWithImpl<$Res>;
+  factory _$$SurfaceStateImplCopyWith(
+          _$SurfaceStateImpl value, $Res Function(_$SurfaceStateImpl) then) =
+      __$$SurfaceStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -160,11 +160,11 @@ abstract class _$$_SurfaceStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SurfaceStateCopyWithImpl<$Res>
-    extends _$SurfaceStateCopyWithImpl<$Res, _$_SurfaceState>
-    implements _$$_SurfaceStateCopyWith<$Res> {
-  __$$_SurfaceStateCopyWithImpl(
-      _$_SurfaceState _value, $Res Function(_$_SurfaceState) _then)
+class __$$SurfaceStateImplCopyWithImpl<$Res>
+    extends _$SurfaceStateCopyWithImpl<$Res, _$SurfaceStateImpl>
+    implements _$$SurfaceStateImplCopyWith<$Res> {
+  __$$SurfaceStateImplCopyWithImpl(
+      _$SurfaceStateImpl _value, $Res Function(_$SurfaceStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -183,7 +183,7 @@ class __$$_SurfaceStateCopyWithImpl<$Res>
     Object? subsurfacesAbove = null,
     Object? inputRegion = null,
   }) {
-    return _then(_$_SurfaceState(
+    return _then(_$SurfaceStateImpl(
       role: null == role
           ? _value.role
           : role // ignore: cast_nullable_to_non_nullable
@@ -238,8 +238,8 @@ class __$$_SurfaceStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_SurfaceState implements _SurfaceState {
-  const _$_SurfaceState(
+class _$SurfaceStateImpl implements _SurfaceState {
+  const _$SurfaceStateImpl(
       {required this.role,
       required this.viewId,
       required this.textureId,
@@ -303,7 +303,7 @@ class _$_SurfaceState implements _SurfaceState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SurfaceState &&
+            other is _$SurfaceStateImpl &&
             (identical(other.role, role) || other.role == role) &&
             (identical(other.viewId, viewId) || other.viewId == viewId) &&
             (identical(other.textureId, textureId) ||
@@ -346,8 +346,8 @@ class _$_SurfaceState implements _SurfaceState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SurfaceStateCopyWith<_$_SurfaceState> get copyWith =>
-      __$$_SurfaceStateCopyWithImpl<_$_SurfaceState>(this, _$identity);
+  _$$SurfaceStateImplCopyWith<_$SurfaceStateImpl> get copyWith =>
+      __$$SurfaceStateImplCopyWithImpl<_$SurfaceStateImpl>(this, _$identity);
 }
 
 abstract class _SurfaceState implements SurfaceState {
@@ -363,7 +363,7 @@ abstract class _SurfaceState implements SurfaceState {
       required final GlobalKey<State<StatefulWidget>> textureKey,
       required final List<int> subsurfacesBelow,
       required final List<int> subsurfacesAbove,
-      required final Rect inputRegion}) = _$_SurfaceState;
+      required final Rect inputRegion}) = _$SurfaceStateImpl;
 
   @override
   SurfaceRole get role;
@@ -391,6 +391,6 @@ abstract class _SurfaceState implements SurfaceState {
   Rect get inputRegion;
   @override
   @JsonKey(ignore: true)
-  _$$_SurfaceStateCopyWith<_$_SurfaceState> get copyWith =>
+  _$$SurfaceStateImplCopyWith<_$SurfaceStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/common/state/surface_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/surface_state.g.dart
@@ -29,8 +29,6 @@ class _SystemHash {
   }
 }
 
-typedef SurfaceWidgetRef = ProviderRef<Surface>;
-
 /// See also [surfaceWidget].
 @ProviderFor(surfaceWidget)
 const surfaceWidgetProvider = SurfaceWidgetFamily();
@@ -77,10 +75,10 @@ class SurfaceWidgetFamily extends Family<Surface> {
 class SurfaceWidgetProvider extends Provider<Surface> {
   /// See also [surfaceWidget].
   SurfaceWidgetProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => surfaceWidget(
-            ref,
+            ref as SurfaceWidgetRef,
             viewId,
           ),
           from: surfaceWidgetProvider,
@@ -92,9 +90,43 @@ class SurfaceWidgetProvider extends Provider<Surface> {
           dependencies: SurfaceWidgetFamily._dependencies,
           allTransitiveDependencies:
               SurfaceWidgetFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  SurfaceWidgetProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    Surface Function(SurfaceWidgetRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: SurfaceWidgetProvider._internal(
+        (ref) => create(ref as SurfaceWidgetRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<Surface> createElement() {
+    return _SurfaceWidgetProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -110,7 +142,20 @@ class SurfaceWidgetProvider extends Provider<Surface> {
   }
 }
 
-String _$surfaceStatesHash() => r'5caa225a3c1de7b3e468b079377ed5e9c7fee3d8';
+mixin SurfaceWidgetRef on ProviderRef<Surface> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _SurfaceWidgetProviderElement extends ProviderElement<Surface>
+    with SurfaceWidgetRef {
+  _SurfaceWidgetProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as SurfaceWidgetProvider).viewId;
+}
+
+String _$surfaceStatesHash() => r'9d292503b8280003f333d367754673ab0187a5c1';
 
 abstract class _$SurfaceStates extends BuildlessNotifier<SurfaceState> {
   late final int viewId;
@@ -167,8 +212,8 @@ class SurfaceStatesProvider
     extends NotifierProviderImpl<SurfaceStates, SurfaceState> {
   /// See also [SurfaceStates].
   SurfaceStatesProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => SurfaceStates()..viewId = viewId,
           from: surfaceStatesProvider,
           name: r'surfaceStatesProvider',
@@ -179,9 +224,50 @@ class SurfaceStatesProvider
           dependencies: SurfaceStatesFamily._dependencies,
           allTransitiveDependencies:
               SurfaceStatesFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  SurfaceStatesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  SurfaceState runNotifierBuild(
+    covariant SurfaceStates notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(SurfaceStates Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: SurfaceStatesProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<SurfaceStates, SurfaceState> createElement() {
+    return _SurfaceStatesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -195,14 +281,20 @@ class SurfaceStatesProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin SurfaceStatesRef on NotifierProviderRef<SurfaceState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _SurfaceStatesProviderElement
+    extends NotifierProviderElement<SurfaceStates, SurfaceState>
+    with SurfaceStatesRef {
+  _SurfaceStatesProviderElement(super.provider);
 
   @override
-  SurfaceState runNotifierBuild(
-    covariant SurfaceStates notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as SurfaceStatesProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/tasks_provider.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/tasks_provider.freezed.dart
@@ -67,22 +67,22 @@ class _$TasksStateCopyWithImpl<$Res, $Val extends TasksState>
 }
 
 /// @nodoc
-abstract class _$$_TasksStateCopyWith<$Res>
+abstract class _$$TasksStateImplCopyWith<$Res>
     implements $TasksStateCopyWith<$Res> {
-  factory _$$_TasksStateCopyWith(
-          _$_TasksState value, $Res Function(_$_TasksState) then) =
-      __$$_TasksStateCopyWithImpl<$Res>;
+  factory _$$TasksStateImplCopyWith(
+          _$TasksStateImpl value, $Res Function(_$TasksStateImpl) then) =
+      __$$TasksStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({IList<int> tasks, IList<DiffOperation<int>> diff});
 }
 
 /// @nodoc
-class __$$_TasksStateCopyWithImpl<$Res>
-    extends _$TasksStateCopyWithImpl<$Res, _$_TasksState>
-    implements _$$_TasksStateCopyWith<$Res> {
-  __$$_TasksStateCopyWithImpl(
-      _$_TasksState _value, $Res Function(_$_TasksState) _then)
+class __$$TasksStateImplCopyWithImpl<$Res>
+    extends _$TasksStateCopyWithImpl<$Res, _$TasksStateImpl>
+    implements _$$TasksStateImplCopyWith<$Res> {
+  __$$TasksStateImplCopyWithImpl(
+      _$TasksStateImpl _value, $Res Function(_$TasksStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -91,7 +91,7 @@ class __$$_TasksStateCopyWithImpl<$Res>
     Object? tasks = null,
     Object? diff = null,
   }) {
-    return _then(_$_TasksState(
+    return _then(_$TasksStateImpl(
       tasks: null == tasks
           ? _value.tasks
           : tasks // ignore: cast_nullable_to_non_nullable
@@ -106,8 +106,8 @@ class __$$_TasksStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_TasksState implements _TasksState {
-  const _$_TasksState({required this.tasks, required this.diff});
+class _$TasksStateImpl implements _TasksState {
+  const _$TasksStateImpl({required this.tasks, required this.diff});
 
   @override
   final IList<int> tasks;
@@ -127,7 +127,7 @@ class _$_TasksState implements _TasksState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TasksState &&
+            other is _$TasksStateImpl &&
             const DeepCollectionEquality().equals(other.tasks, tasks) &&
             const DeepCollectionEquality().equals(other.diff, diff));
   }
@@ -141,14 +141,14 @@ class _$_TasksState implements _TasksState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TasksStateCopyWith<_$_TasksState> get copyWith =>
-      __$$_TasksStateCopyWithImpl<_$_TasksState>(this, _$identity);
+  _$$TasksStateImplCopyWith<_$TasksStateImpl> get copyWith =>
+      __$$TasksStateImplCopyWithImpl<_$TasksStateImpl>(this, _$identity);
 }
 
 abstract class _TasksState implements TasksState {
   const factory _TasksState(
       {required final IList<int> tasks,
-      required final IList<DiffOperation<int>> diff}) = _$_TasksState;
+      required final IList<DiffOperation<int>> diff}) = _$TasksStateImpl;
 
   @override
   IList<int> get tasks;
@@ -160,6 +160,6 @@ abstract class _TasksState implements TasksState {
   IList<DiffOperation<int>> get diff;
   @override
   @JsonKey(ignore: true)
-  _$$_TasksStateCopyWith<_$_TasksState> get copyWith =>
+  _$$TasksStateImplCopyWith<_$TasksStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/common/state/tasks_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/tasks_provider.g.dart
@@ -20,4 +20,5 @@ final tasksProvider = NotifierProvider<Tasks, TasksState>.internal(
 );
 
 typedef _$Tasks = Notifier<TasksState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/xdg_popup_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/xdg_popup_state.freezed.dart
@@ -80,11 +80,11 @@ class _$XdgPopupStateCopyWithImpl<$Res, $Val extends XdgPopupState>
 }
 
 /// @nodoc
-abstract class _$$_XdgPopupStateCopyWith<$Res>
+abstract class _$$XdgPopupStateImplCopyWith<$Res>
     implements $XdgPopupStateCopyWith<$Res> {
-  factory _$$_XdgPopupStateCopyWith(
-          _$_XdgPopupState value, $Res Function(_$_XdgPopupState) then) =
-      __$$_XdgPopupStateCopyWithImpl<$Res>;
+  factory _$$XdgPopupStateImplCopyWith(
+          _$XdgPopupStateImpl value, $Res Function(_$XdgPopupStateImpl) then) =
+      __$$XdgPopupStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -95,11 +95,11 @@ abstract class _$$_XdgPopupStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_XdgPopupStateCopyWithImpl<$Res>
-    extends _$XdgPopupStateCopyWithImpl<$Res, _$_XdgPopupState>
-    implements _$$_XdgPopupStateCopyWith<$Res> {
-  __$$_XdgPopupStateCopyWithImpl(
-      _$_XdgPopupState _value, $Res Function(_$_XdgPopupState) _then)
+class __$$XdgPopupStateImplCopyWithImpl<$Res>
+    extends _$XdgPopupStateCopyWithImpl<$Res, _$XdgPopupStateImpl>
+    implements _$$XdgPopupStateImplCopyWith<$Res> {
+  __$$XdgPopupStateImplCopyWithImpl(
+      _$XdgPopupStateImpl _value, $Res Function(_$XdgPopupStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -110,7 +110,7 @@ class __$$_XdgPopupStateCopyWithImpl<$Res>
     Object? animationsKey = null,
     Object? isClosing = null,
   }) {
-    return _then(_$_XdgPopupState(
+    return _then(_$XdgPopupStateImpl(
       parentViewId: null == parentViewId
           ? _value.parentViewId
           : parentViewId // ignore: cast_nullable_to_non_nullable
@@ -133,8 +133,10 @@ class __$$_XdgPopupStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_XdgPopupState with DiagnosticableTreeMixin implements _XdgPopupState {
-  const _$_XdgPopupState(
+class _$XdgPopupStateImpl
+    with DiagnosticableTreeMixin
+    implements _XdgPopupState {
+  const _$XdgPopupStateImpl(
       {required this.parentViewId,
       required this.position,
       required this.animationsKey,
@@ -169,7 +171,7 @@ class _$_XdgPopupState with DiagnosticableTreeMixin implements _XdgPopupState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_XdgPopupState &&
+            other is _$XdgPopupStateImpl &&
             (identical(other.parentViewId, parentViewId) ||
                 other.parentViewId == parentViewId) &&
             (identical(other.position, position) ||
@@ -187,8 +189,8 @@ class _$_XdgPopupState with DiagnosticableTreeMixin implements _XdgPopupState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_XdgPopupStateCopyWith<_$_XdgPopupState> get copyWith =>
-      __$$_XdgPopupStateCopyWithImpl<_$_XdgPopupState>(this, _$identity);
+  _$$XdgPopupStateImplCopyWith<_$XdgPopupStateImpl> get copyWith =>
+      __$$XdgPopupStateImplCopyWithImpl<_$XdgPopupStateImpl>(this, _$identity);
 }
 
 abstract class _XdgPopupState implements XdgPopupState {
@@ -196,7 +198,7 @@ abstract class _XdgPopupState implements XdgPopupState {
       {required final int parentViewId,
       required final Offset position,
       required final GlobalKey<AnimationsState> animationsKey,
-      required final bool isClosing}) = _$_XdgPopupState;
+      required final bool isClosing}) = _$XdgPopupStateImpl;
 
   @override
   int get parentViewId;
@@ -208,6 +210,6 @@ abstract class _XdgPopupState implements XdgPopupState {
   bool get isClosing;
   @override
   @JsonKey(ignore: true)
-  _$$_XdgPopupStateCopyWith<_$_XdgPopupState> get copyWith =>
+  _$$XdgPopupStateImplCopyWith<_$XdgPopupStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/common/state/xdg_popup_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/xdg_popup_state.g.dart
@@ -29,8 +29,6 @@ class _SystemHash {
   }
 }
 
-typedef PopupWidgetRef = ProviderRef<Popup>;
-
 /// See also [popupWidget].
 @ProviderFor(popupWidget)
 const popupWidgetProvider = PopupWidgetFamily();
@@ -77,10 +75,10 @@ class PopupWidgetFamily extends Family<Popup> {
 class PopupWidgetProvider extends Provider<Popup> {
   /// See also [popupWidget].
   PopupWidgetProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => popupWidget(
-            ref,
+            ref as PopupWidgetRef,
             viewId,
           ),
           from: popupWidgetProvider,
@@ -92,9 +90,43 @@ class PopupWidgetProvider extends Provider<Popup> {
           dependencies: PopupWidgetFamily._dependencies,
           allTransitiveDependencies:
               PopupWidgetFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  PopupWidgetProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    Popup Function(PopupWidgetRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: PopupWidgetProvider._internal(
+        (ref) => create(ref as PopupWidgetRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<Popup> createElement() {
+    return _PopupWidgetProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -108,6 +140,19 @@ class PopupWidgetProvider extends Provider<Popup> {
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin PopupWidgetRef on ProviderRef<Popup> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _PopupWidgetProviderElement extends ProviderElement<Popup>
+    with PopupWidgetRef {
+  _PopupWidgetProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as PopupWidgetProvider).viewId;
 }
 
 String _$xdgPopupStatesHash() => r'21bc9d8c0b8e062e6c78cffe58f2d68182aad623';
@@ -167,8 +212,8 @@ class XdgPopupStatesProvider
     extends NotifierProviderImpl<XdgPopupStates, XdgPopupState> {
   /// See also [XdgPopupStates].
   XdgPopupStatesProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => XdgPopupStates()..viewId = viewId,
           from: xdgPopupStatesProvider,
           name: r'xdgPopupStatesProvider',
@@ -179,9 +224,50 @@ class XdgPopupStatesProvider
           dependencies: XdgPopupStatesFamily._dependencies,
           allTransitiveDependencies:
               XdgPopupStatesFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  XdgPopupStatesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  XdgPopupState runNotifierBuild(
+    covariant XdgPopupStates notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(XdgPopupStates Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: XdgPopupStatesProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<XdgPopupStates, XdgPopupState> createElement() {
+    return _XdgPopupStatesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -195,14 +281,20 @@ class XdgPopupStatesProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin XdgPopupStatesRef on NotifierProviderRef<XdgPopupState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _XdgPopupStatesProviderElement
+    extends NotifierProviderElement<XdgPopupStates, XdgPopupState>
+    with XdgPopupStatesRef {
+  _XdgPopupStatesProviderElement(super.provider);
 
   @override
-  XdgPopupState runNotifierBuild(
-    covariant XdgPopupStates notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as XdgPopupStatesProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/xdg_surface_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/xdg_surface_state.freezed.dart
@@ -16,8 +16,8 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$XdgSurfaceState {
-  XdgSurfaceRole get role => throw _privateConstructorUsedError;
   bool get mapped => throw _privateConstructorUsedError;
+  XdgSurfaceRole get role => throw _privateConstructorUsedError;
   Rect get visibleBounds => throw _privateConstructorUsedError;
   GlobalKey<State<StatefulWidget>> get widgetKey =>
       throw _privateConstructorUsedError;
@@ -35,8 +35,8 @@ abstract class $XdgSurfaceStateCopyWith<$Res> {
       _$XdgSurfaceStateCopyWithImpl<$Res, XdgSurfaceState>;
   @useResult
   $Res call(
-      {XdgSurfaceRole role,
-      bool mapped,
+      {bool mapped,
+      XdgSurfaceRole role,
       Rect visibleBounds,
       GlobalKey<State<StatefulWidget>> widgetKey,
       List<int> popups});
@@ -55,21 +55,21 @@ class _$XdgSurfaceStateCopyWithImpl<$Res, $Val extends XdgSurfaceState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? role = null,
     Object? mapped = null,
+    Object? role = null,
     Object? visibleBounds = null,
     Object? widgetKey = null,
     Object? popups = null,
   }) {
     return _then(_value.copyWith(
-      role: null == role
-          ? _value.role
-          : role // ignore: cast_nullable_to_non_nullable
-              as XdgSurfaceRole,
       mapped: null == mapped
           ? _value.mapped
           : mapped // ignore: cast_nullable_to_non_nullable
               as bool,
+      role: null == role
+          ? _value.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as XdgSurfaceRole,
       visibleBounds: null == visibleBounds
           ? _value.visibleBounds
           : visibleBounds // ignore: cast_nullable_to_non_nullable
@@ -87,47 +87,47 @@ class _$XdgSurfaceStateCopyWithImpl<$Res, $Val extends XdgSurfaceState>
 }
 
 /// @nodoc
-abstract class _$$_XdgSurfaceStateCopyWith<$Res>
+abstract class _$$XdgSurfaceStateImplCopyWith<$Res>
     implements $XdgSurfaceStateCopyWith<$Res> {
-  factory _$$_XdgSurfaceStateCopyWith(
-          _$_XdgSurfaceState value, $Res Function(_$_XdgSurfaceState) then) =
-      __$$_XdgSurfaceStateCopyWithImpl<$Res>;
+  factory _$$XdgSurfaceStateImplCopyWith(_$XdgSurfaceStateImpl value,
+          $Res Function(_$XdgSurfaceStateImpl) then) =
+      __$$XdgSurfaceStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {XdgSurfaceRole role,
-      bool mapped,
+      {bool mapped,
+      XdgSurfaceRole role,
       Rect visibleBounds,
       GlobalKey<State<StatefulWidget>> widgetKey,
       List<int> popups});
 }
 
 /// @nodoc
-class __$$_XdgSurfaceStateCopyWithImpl<$Res>
-    extends _$XdgSurfaceStateCopyWithImpl<$Res, _$_XdgSurfaceState>
-    implements _$$_XdgSurfaceStateCopyWith<$Res> {
-  __$$_XdgSurfaceStateCopyWithImpl(
-      _$_XdgSurfaceState _value, $Res Function(_$_XdgSurfaceState) _then)
+class __$$XdgSurfaceStateImplCopyWithImpl<$Res>
+    extends _$XdgSurfaceStateCopyWithImpl<$Res, _$XdgSurfaceStateImpl>
+    implements _$$XdgSurfaceStateImplCopyWith<$Res> {
+  __$$XdgSurfaceStateImplCopyWithImpl(
+      _$XdgSurfaceStateImpl _value, $Res Function(_$XdgSurfaceStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? role = null,
     Object? mapped = null,
+    Object? role = null,
     Object? visibleBounds = null,
     Object? widgetKey = null,
     Object? popups = null,
   }) {
-    return _then(_$_XdgSurfaceState(
-      role: null == role
-          ? _value.role
-          : role // ignore: cast_nullable_to_non_nullable
-              as XdgSurfaceRole,
+    return _then(_$XdgSurfaceStateImpl(
       mapped: null == mapped
           ? _value.mapped
           : mapped // ignore: cast_nullable_to_non_nullable
               as bool,
+      role: null == role
+          ? _value.role
+          : role // ignore: cast_nullable_to_non_nullable
+              as XdgSurfaceRole,
       visibleBounds: null == visibleBounds
           ? _value.visibleBounds
           : visibleBounds // ignore: cast_nullable_to_non_nullable
@@ -146,21 +146,21 @@ class __$$_XdgSurfaceStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_XdgSurfaceState
+class _$XdgSurfaceStateImpl
     with DiagnosticableTreeMixin
     implements _XdgSurfaceState {
-  const _$_XdgSurfaceState(
-      {required this.role,
-      required this.mapped,
+  const _$XdgSurfaceStateImpl(
+      {required this.mapped,
+      required this.role,
       required this.visibleBounds,
       required this.widgetKey,
       required final List<int> popups})
       : _popups = popups;
 
   @override
-  final XdgSurfaceRole role;
-  @override
   final bool mapped;
+  @override
+  final XdgSurfaceRole role;
   @override
   final Rect visibleBounds;
   @override
@@ -175,7 +175,7 @@ class _$_XdgSurfaceState
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'XdgSurfaceState(role: $role, mapped: $mapped, visibleBounds: $visibleBounds, widgetKey: $widgetKey, popups: $popups)';
+    return 'XdgSurfaceState(mapped: $mapped, role: $role, visibleBounds: $visibleBounds, widgetKey: $widgetKey, popups: $popups)';
   }
 
   @override
@@ -183,8 +183,8 @@ class _$_XdgSurfaceState
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('type', 'XdgSurfaceState'))
-      ..add(DiagnosticsProperty('role', role))
       ..add(DiagnosticsProperty('mapped', mapped))
+      ..add(DiagnosticsProperty('role', role))
       ..add(DiagnosticsProperty('visibleBounds', visibleBounds))
       ..add(DiagnosticsProperty('widgetKey', widgetKey))
       ..add(DiagnosticsProperty('popups', popups));
@@ -194,9 +194,9 @@ class _$_XdgSurfaceState
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_XdgSurfaceState &&
-            (identical(other.role, role) || other.role == role) &&
+            other is _$XdgSurfaceStateImpl &&
             (identical(other.mapped, mapped) || other.mapped == mapped) &&
+            (identical(other.role, role) || other.role == role) &&
             (identical(other.visibleBounds, visibleBounds) ||
                 other.visibleBounds == visibleBounds) &&
             (identical(other.widgetKey, widgetKey) ||
@@ -205,28 +205,29 @@ class _$_XdgSurfaceState
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, role, mapped, visibleBounds,
+  int get hashCode => Object.hash(runtimeType, mapped, role, visibleBounds,
       widgetKey, const DeepCollectionEquality().hash(_popups));
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_XdgSurfaceStateCopyWith<_$_XdgSurfaceState> get copyWith =>
-      __$$_XdgSurfaceStateCopyWithImpl<_$_XdgSurfaceState>(this, _$identity);
+  _$$XdgSurfaceStateImplCopyWith<_$XdgSurfaceStateImpl> get copyWith =>
+      __$$XdgSurfaceStateImplCopyWithImpl<_$XdgSurfaceStateImpl>(
+          this, _$identity);
 }
 
 abstract class _XdgSurfaceState implements XdgSurfaceState {
   const factory _XdgSurfaceState(
-      {required final XdgSurfaceRole role,
-      required final bool mapped,
+      {required final bool mapped,
+      required final XdgSurfaceRole role,
       required final Rect visibleBounds,
       required final GlobalKey<State<StatefulWidget>> widgetKey,
-      required final List<int> popups}) = _$_XdgSurfaceState;
+      required final List<int> popups}) = _$XdgSurfaceStateImpl;
 
   @override
-  XdgSurfaceRole get role;
-  @override
   bool get mapped;
+  @override
+  XdgSurfaceRole get role;
   @override
   Rect get visibleBounds;
   @override
@@ -235,6 +236,6 @@ abstract class _XdgSurfaceState implements XdgSurfaceState {
   List<int> get popups;
   @override
   @JsonKey(ignore: true)
-  _$$_XdgSurfaceStateCopyWith<_$_XdgSurfaceState> get copyWith =>
+  _$$XdgSurfaceStateImplCopyWith<_$XdgSurfaceStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/common/state/xdg_surface_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/xdg_surface_state.g.dart
@@ -6,7 +6,7 @@ part of '../../../../ui/common/state/xdg_surface_state.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$xdgSurfaceStatesHash() => r'604f2bfdfc7819f81145941643b4b99e59c72c65';
+String _$xdgSurfaceStatesHash() => r'def7803523154cdaa9fcb46a8bf7439a682cc0ca';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -84,8 +84,8 @@ class XdgSurfaceStatesProvider
     extends NotifierProviderImpl<XdgSurfaceStates, XdgSurfaceState> {
   /// See also [XdgSurfaceStates].
   XdgSurfaceStatesProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => XdgSurfaceStates()..viewId = viewId,
           from: xdgSurfaceStatesProvider,
           name: r'xdgSurfaceStatesProvider',
@@ -96,9 +96,50 @@ class XdgSurfaceStatesProvider
           dependencies: XdgSurfaceStatesFamily._dependencies,
           allTransitiveDependencies:
               XdgSurfaceStatesFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  XdgSurfaceStatesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  XdgSurfaceState runNotifierBuild(
+    covariant XdgSurfaceStates notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(XdgSurfaceStates Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: XdgSurfaceStatesProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<XdgSurfaceStates, XdgSurfaceState> createElement() {
+    return _XdgSurfaceStatesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -112,14 +153,20 @@ class XdgSurfaceStatesProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin XdgSurfaceStatesRef on NotifierProviderRef<XdgSurfaceState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _XdgSurfaceStatesProviderElement
+    extends NotifierProviderElement<XdgSurfaceStates, XdgSurfaceState>
+    with XdgSurfaceStatesRef {
+  _XdgSurfaceStatesProviderElement(super.provider);
 
   @override
-  XdgSurfaceState runNotifierBuild(
-    covariant XdgSurfaceStates notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as XdgSurfaceStatesProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/common/state/xdg_toplevel_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/xdg_toplevel_state.freezed.dart
@@ -114,11 +114,11 @@ class _$XdgToplevelStateCopyWithImpl<$Res, $Val extends XdgToplevelState>
 }
 
 /// @nodoc
-abstract class _$$_XdgToplevelStateCopyWith<$Res>
+abstract class _$$XdgToplevelStateImplCopyWith<$Res>
     implements $XdgToplevelStateCopyWith<$Res> {
-  factory _$$_XdgToplevelStateCopyWith(
-          _$_XdgToplevelState value, $Res Function(_$_XdgToplevelState) then) =
-      __$$_XdgToplevelStateCopyWithImpl<$Res>;
+  factory _$$XdgToplevelStateImplCopyWith(_$XdgToplevelStateImpl value,
+          $Res Function(_$XdgToplevelStateImpl) then) =
+      __$$XdgToplevelStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -134,11 +134,11 @@ abstract class _$$_XdgToplevelStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_XdgToplevelStateCopyWithImpl<$Res>
-    extends _$XdgToplevelStateCopyWithImpl<$Res, _$_XdgToplevelState>
-    implements _$$_XdgToplevelStateCopyWith<$Res> {
-  __$$_XdgToplevelStateCopyWithImpl(
-      _$_XdgToplevelState _value, $Res Function(_$_XdgToplevelState) _then)
+class __$$XdgToplevelStateImplCopyWithImpl<$Res>
+    extends _$XdgToplevelStateCopyWithImpl<$Res, _$XdgToplevelStateImpl>
+    implements _$$XdgToplevelStateImplCopyWith<$Res> {
+  __$$XdgToplevelStateImplCopyWithImpl(_$XdgToplevelStateImpl _value,
+      $Res Function(_$XdgToplevelStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -154,7 +154,7 @@ class __$$_XdgToplevelStateCopyWithImpl<$Res>
     Object? appId = null,
     Object? tilingRequested = freezed,
   }) {
-    return _then(_$_XdgToplevelState(
+    return _then(_$XdgToplevelStateImpl(
       visible: null == visible
           ? _value.visible
           : visible // ignore: cast_nullable_to_non_nullable
@@ -196,8 +196,8 @@ class __$$_XdgToplevelStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_XdgToplevelState implements _XdgToplevelState {
-  const _$_XdgToplevelState(
+class _$XdgToplevelStateImpl implements _XdgToplevelState {
+  const _$XdgToplevelStateImpl(
       {required this.visible,
       required this.virtualKeyboardKey,
       required this.focusNode,
@@ -236,7 +236,7 @@ class _$_XdgToplevelState implements _XdgToplevelState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_XdgToplevelState &&
+            other is _$XdgToplevelStateImpl &&
             (identical(other.visible, visible) || other.visible == visible) &&
             (identical(other.virtualKeyboardKey, virtualKeyboardKey) ||
                 other.virtualKeyboardKey == virtualKeyboardKey) &&
@@ -272,8 +272,9 @@ class _$_XdgToplevelState implements _XdgToplevelState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_XdgToplevelStateCopyWith<_$_XdgToplevelState> get copyWith =>
-      __$$_XdgToplevelStateCopyWithImpl<_$_XdgToplevelState>(this, _$identity);
+  _$$XdgToplevelStateImplCopyWith<_$XdgToplevelStateImpl> get copyWith =>
+      __$$XdgToplevelStateImplCopyWithImpl<_$XdgToplevelStateImpl>(
+          this, _$identity);
 }
 
 abstract class _XdgToplevelState implements XdgToplevelState {
@@ -286,7 +287,7 @@ abstract class _XdgToplevelState implements XdgToplevelState {
       required final ToplevelDecoration decoration,
       required final String title,
       required final String appId,
-      required final Tiling? tilingRequested}) = _$_XdgToplevelState;
+      required final Tiling? tilingRequested}) = _$XdgToplevelStateImpl;
 
   @override
   bool get visible;
@@ -308,6 +309,6 @@ abstract class _XdgToplevelState implements XdgToplevelState {
   Tiling? get tilingRequested;
   @override
   @JsonKey(ignore: true)
-  _$$_XdgToplevelStateCopyWith<_$_XdgToplevelState> get copyWith =>
+  _$$XdgToplevelStateImplCopyWith<_$XdgToplevelStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/common/state/xdg_toplevel_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/common/state/xdg_toplevel_state.g.dart
@@ -30,8 +30,6 @@ class _SystemHash {
   }
 }
 
-typedef XdgToplevelSurfaceWidgetRef = ProviderRef<XdgToplevelSurface>;
-
 /// See also [xdgToplevelSurfaceWidget].
 @ProviderFor(xdgToplevelSurfaceWidget)
 const xdgToplevelSurfaceWidgetProvider = XdgToplevelSurfaceWidgetFamily();
@@ -78,10 +76,10 @@ class XdgToplevelSurfaceWidgetFamily extends Family<XdgToplevelSurface> {
 class XdgToplevelSurfaceWidgetProvider extends Provider<XdgToplevelSurface> {
   /// See also [xdgToplevelSurfaceWidget].
   XdgToplevelSurfaceWidgetProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => xdgToplevelSurfaceWidget(
-            ref,
+            ref as XdgToplevelSurfaceWidgetRef,
             viewId,
           ),
           from: xdgToplevelSurfaceWidgetProvider,
@@ -93,9 +91,43 @@ class XdgToplevelSurfaceWidgetProvider extends Provider<XdgToplevelSurface> {
           dependencies: XdgToplevelSurfaceWidgetFamily._dependencies,
           allTransitiveDependencies:
               XdgToplevelSurfaceWidgetFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  XdgToplevelSurfaceWidgetProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    XdgToplevelSurface Function(XdgToplevelSurfaceWidgetRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: XdgToplevelSurfaceWidgetProvider._internal(
+        (ref) => create(ref as XdgToplevelSurfaceWidgetRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<XdgToplevelSurface> createElement() {
+    return _XdgToplevelSurfaceWidgetProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -109,6 +141,20 @@ class XdgToplevelSurfaceWidgetProvider extends Provider<XdgToplevelSurface> {
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin XdgToplevelSurfaceWidgetRef on ProviderRef<XdgToplevelSurface> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _XdgToplevelSurfaceWidgetProviderElement
+    extends ProviderElement<XdgToplevelSurface>
+    with XdgToplevelSurfaceWidgetRef {
+  _XdgToplevelSurfaceWidgetProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as XdgToplevelSurfaceWidgetProvider).viewId;
 }
 
 String _$xdgToplevelStatesHash() => r'df3d83b090758345e241bc50c1d90347227dd84b';
@@ -168,8 +214,8 @@ class XdgToplevelStatesProvider
     extends NotifierProviderImpl<XdgToplevelStates, XdgToplevelState> {
   /// See also [XdgToplevelStates].
   XdgToplevelStatesProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => XdgToplevelStates()..viewId = viewId,
           from: xdgToplevelStatesProvider,
           name: r'xdgToplevelStatesProvider',
@@ -180,9 +226,50 @@ class XdgToplevelStatesProvider
           dependencies: XdgToplevelStatesFamily._dependencies,
           allTransitiveDependencies:
               XdgToplevelStatesFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  XdgToplevelStatesProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  XdgToplevelState runNotifierBuild(
+    covariant XdgToplevelStates notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(XdgToplevelStates Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: XdgToplevelStatesProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<XdgToplevelStates, XdgToplevelState> createElement() {
+    return _XdgToplevelStatesProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -196,14 +283,20 @@ class XdgToplevelStatesProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin XdgToplevelStatesRef on NotifierProviderRef<XdgToplevelState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _XdgToplevelStatesProviderElement
+    extends NotifierProviderElement<XdgToplevelStates, XdgToplevelState>
+    with XdgToplevelStatesRef {
+  _XdgToplevelStatesProviderElement(super.provider);
 
   @override
-  XdgToplevelState runNotifierBuild(
-    covariant XdgToplevelStates notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as XdgToplevelStatesProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/app_drawer/app_drawer_button.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/app_drawer/app_drawer_button.g.dart
@@ -22,4 +22,5 @@ final appDrawerVisibleProvider =
 );
 
 typedef _$AppDrawerVisible = Notifier<bool>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/app_drawer/app_grid.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/app_drawer/app_grid.g.dart
@@ -21,4 +21,5 @@ final appEntryWidgetProvider = Provider<List<AppEntry>>.internal(
 );
 
 typedef AppEntryWidgetRef = ProviderRef<List<AppEntry>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/cursor_position_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/cursor_position_provider.g.dart
@@ -22,4 +22,5 @@ final cursorPositionProvider =
 );
 
 typedef _$CursorPosition = Notifier<Offset>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/task_switcher_provider.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/task_switcher_provider.freezed.dart
@@ -63,22 +63,22 @@ class _$TaskSwitcherStateCopyWithImpl<$Res, $Val extends TaskSwitcherState>
 }
 
 /// @nodoc
-abstract class _$$_TaskSwitcherStateCopyWith<$Res>
+abstract class _$$TaskSwitcherStateImplCopyWith<$Res>
     implements $TaskSwitcherStateCopyWith<$Res> {
-  factory _$$_TaskSwitcherStateCopyWith(_$_TaskSwitcherState value,
-          $Res Function(_$_TaskSwitcherState) then) =
-      __$$_TaskSwitcherStateCopyWithImpl<$Res>;
+  factory _$$TaskSwitcherStateImplCopyWith(_$TaskSwitcherStateImpl value,
+          $Res Function(_$TaskSwitcherStateImpl) then) =
+      __$$TaskSwitcherStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool shown, int index});
 }
 
 /// @nodoc
-class __$$_TaskSwitcherStateCopyWithImpl<$Res>
-    extends _$TaskSwitcherStateCopyWithImpl<$Res, _$_TaskSwitcherState>
-    implements _$$_TaskSwitcherStateCopyWith<$Res> {
-  __$$_TaskSwitcherStateCopyWithImpl(
-      _$_TaskSwitcherState _value, $Res Function(_$_TaskSwitcherState) _then)
+class __$$TaskSwitcherStateImplCopyWithImpl<$Res>
+    extends _$TaskSwitcherStateCopyWithImpl<$Res, _$TaskSwitcherStateImpl>
+    implements _$$TaskSwitcherStateImplCopyWith<$Res> {
+  __$$TaskSwitcherStateImplCopyWithImpl(_$TaskSwitcherStateImpl _value,
+      $Res Function(_$TaskSwitcherStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -87,7 +87,7 @@ class __$$_TaskSwitcherStateCopyWithImpl<$Res>
     Object? shown = null,
     Object? index = null,
   }) {
-    return _then(_$_TaskSwitcherState(
+    return _then(_$TaskSwitcherStateImpl(
       shown: null == shown
           ? _value.shown
           : shown // ignore: cast_nullable_to_non_nullable
@@ -102,8 +102,8 @@ class __$$_TaskSwitcherStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_TaskSwitcherState implements _TaskSwitcherState {
-  const _$_TaskSwitcherState({required this.shown, required this.index});
+class _$TaskSwitcherStateImpl implements _TaskSwitcherState {
+  const _$TaskSwitcherStateImpl({required this.shown, required this.index});
 
   @override
   final bool shown;
@@ -119,7 +119,7 @@ class _$_TaskSwitcherState implements _TaskSwitcherState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TaskSwitcherState &&
+            other is _$TaskSwitcherStateImpl &&
             (identical(other.shown, shown) || other.shown == shown) &&
             (identical(other.index, index) || other.index == index));
   }
@@ -130,15 +130,15 @@ class _$_TaskSwitcherState implements _TaskSwitcherState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TaskSwitcherStateCopyWith<_$_TaskSwitcherState> get copyWith =>
-      __$$_TaskSwitcherStateCopyWithImpl<_$_TaskSwitcherState>(
+  _$$TaskSwitcherStateImplCopyWith<_$TaskSwitcherStateImpl> get copyWith =>
+      __$$TaskSwitcherStateImplCopyWithImpl<_$TaskSwitcherStateImpl>(
           this, _$identity);
 }
 
 abstract class _TaskSwitcherState implements TaskSwitcherState {
   const factory _TaskSwitcherState(
       {required final bool shown,
-      required final int index}) = _$_TaskSwitcherState;
+      required final int index}) = _$TaskSwitcherStateImpl;
 
   @override
   bool get shown;
@@ -146,6 +146,6 @@ abstract class _TaskSwitcherState implements TaskSwitcherState {
   int get index;
   @override
   @JsonKey(ignore: true)
-  _$$_TaskSwitcherStateCopyWith<_$_TaskSwitcherState> get copyWith =>
+  _$$TaskSwitcherStateImplCopyWith<_$TaskSwitcherStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/desktop/state/task_switcher_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/task_switcher_provider.g.dart
@@ -21,4 +21,5 @@ final taskSwitcherProvider =
 );
 
 typedef _$TaskSwitcher = Notifier<TaskSwitcherState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_move_provider.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_move_provider.freezed.dart
@@ -76,11 +76,11 @@ class _$WindowMoveStateCopyWithImpl<$Res, $Val extends WindowMoveState>
 }
 
 /// @nodoc
-abstract class _$$_WindowMoveStateCopyWith<$Res>
+abstract class _$$WindowMoveStateImplCopyWith<$Res>
     implements $WindowMoveStateCopyWith<$Res> {
-  factory _$$_WindowMoveStateCopyWith(
-          _$_WindowMoveState value, $Res Function(_$_WindowMoveState) then) =
-      __$$_WindowMoveStateCopyWithImpl<$Res>;
+  factory _$$WindowMoveStateImplCopyWith(_$WindowMoveStateImpl value,
+          $Res Function(_$WindowMoveStateImpl) then) =
+      __$$WindowMoveStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -88,11 +88,11 @@ abstract class _$$_WindowMoveStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_WindowMoveStateCopyWithImpl<$Res>
-    extends _$WindowMoveStateCopyWithImpl<$Res, _$_WindowMoveState>
-    implements _$$_WindowMoveStateCopyWith<$Res> {
-  __$$_WindowMoveStateCopyWithImpl(
-      _$_WindowMoveState _value, $Res Function(_$_WindowMoveState) _then)
+class __$$WindowMoveStateImplCopyWithImpl<$Res>
+    extends _$WindowMoveStateCopyWithImpl<$Res, _$WindowMoveStateImpl>
+    implements _$$WindowMoveStateImplCopyWith<$Res> {
+  __$$WindowMoveStateImplCopyWithImpl(
+      _$WindowMoveStateImpl _value, $Res Function(_$WindowMoveStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -103,7 +103,7 @@ class __$$_WindowMoveStateCopyWithImpl<$Res>
     Object? movedPosition = null,
     Object? delta = null,
   }) {
-    return _then(_$_WindowMoveState(
+    return _then(_$WindowMoveStateImpl(
       moving: null == moving
           ? _value.moving
           : moving // ignore: cast_nullable_to_non_nullable
@@ -126,8 +126,8 @@ class __$$_WindowMoveStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_WindowMoveState implements _WindowMoveState {
-  const _$_WindowMoveState(
+class _$WindowMoveStateImpl implements _WindowMoveState {
+  const _$WindowMoveStateImpl(
       {required this.moving,
       required this.startPosition,
       required this.movedPosition,
@@ -151,7 +151,7 @@ class _$_WindowMoveState implements _WindowMoveState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_WindowMoveState &&
+            other is _$WindowMoveStateImpl &&
             (identical(other.moving, moving) || other.moving == moving) &&
             (identical(other.startPosition, startPosition) ||
                 other.startPosition == startPosition) &&
@@ -167,8 +167,9 @@ class _$_WindowMoveState implements _WindowMoveState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_WindowMoveStateCopyWith<_$_WindowMoveState> get copyWith =>
-      __$$_WindowMoveStateCopyWithImpl<_$_WindowMoveState>(this, _$identity);
+  _$$WindowMoveStateImplCopyWith<_$WindowMoveStateImpl> get copyWith =>
+      __$$WindowMoveStateImplCopyWithImpl<_$WindowMoveStateImpl>(
+          this, _$identity);
 }
 
 abstract class _WindowMoveState implements WindowMoveState {
@@ -176,7 +177,7 @@ abstract class _WindowMoveState implements WindowMoveState {
       {required final bool moving,
       required final Offset startPosition,
       required final Offset movedPosition,
-      required final Offset delta}) = _$_WindowMoveState;
+      required final Offset delta}) = _$WindowMoveStateImpl;
 
   @override
   bool get moving;
@@ -188,6 +189,6 @@ abstract class _WindowMoveState implements WindowMoveState {
   Offset get delta;
   @override
   @JsonKey(ignore: true)
-  _$$_WindowMoveStateCopyWith<_$_WindowMoveState> get copyWith =>
+  _$$WindowMoveStateImplCopyWith<_$WindowMoveStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_move_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_move_provider.g.dart
@@ -84,8 +84,8 @@ class WindowMoveProvider
     extends NotifierProviderImpl<WindowMove, WindowMoveState> {
   /// See also [WindowMove].
   WindowMoveProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => WindowMove()..viewId = viewId,
           from: windowMoveProvider,
           name: r'windowMoveProvider',
@@ -96,9 +96,50 @@ class WindowMoveProvider
           dependencies: WindowMoveFamily._dependencies,
           allTransitiveDependencies:
               WindowMoveFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  WindowMoveProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  WindowMoveState runNotifierBuild(
+    covariant WindowMove notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(WindowMove Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: WindowMoveProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<WindowMove, WindowMoveState> createElement() {
+    return _WindowMoveProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -112,14 +153,20 @@ class WindowMoveProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin WindowMoveRef on NotifierProviderRef<WindowMoveState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _WindowMoveProviderElement
+    extends NotifierProviderElement<WindowMove, WindowMoveState>
+    with WindowMoveRef {
+  _WindowMoveProviderElement(super.provider);
 
   @override
-  WindowMoveState runNotifierBuild(
-    covariant WindowMove notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as WindowMoveProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_position_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_position_provider.g.dart
@@ -84,8 +84,8 @@ class WindowPositionProvider
     extends NotifierProviderImpl<WindowPosition, Offset> {
   /// See also [WindowPosition].
   WindowPositionProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => WindowPosition()..viewId = viewId,
           from: windowPositionProvider,
           name: r'windowPositionProvider',
@@ -96,9 +96,50 @@ class WindowPositionProvider
           dependencies: WindowPositionFamily._dependencies,
           allTransitiveDependencies:
               WindowPositionFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  WindowPositionProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Offset runNotifierBuild(
+    covariant WindowPosition notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(WindowPosition Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: WindowPositionProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<WindowPosition, Offset> createElement() {
+    return _WindowPositionProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -112,14 +153,20 @@ class WindowPositionProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin WindowPositionRef on NotifierProviderRef<Offset> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _WindowPositionProviderElement
+    extends NotifierProviderElement<WindowPosition, Offset>
+    with WindowPositionRef {
+  _WindowPositionProviderElement(super.provider);
 
   @override
-  Offset runNotifierBuild(
-    covariant WindowPosition notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as WindowPositionProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_resize_provider.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_resize_provider.freezed.dart
@@ -86,11 +86,11 @@ class _$ResizerStateCopyWithImpl<$Res, $Val extends ResizerState>
 }
 
 /// @nodoc
-abstract class _$$_ResizerStateCopyWith<$Res>
+abstract class _$$ResizerStateImplCopyWith<$Res>
     implements $ResizerStateCopyWith<$Res> {
-  factory _$$_ResizerStateCopyWith(
-          _$_ResizerState value, $Res Function(_$_ResizerState) then) =
-      __$$_ResizerStateCopyWithImpl<$Res>;
+  factory _$$ResizerStateImplCopyWith(
+          _$ResizerStateImpl value, $Res Function(_$ResizerStateImpl) then) =
+      __$$ResizerStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -102,11 +102,11 @@ abstract class _$$_ResizerStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ResizerStateCopyWithImpl<$Res>
-    extends _$ResizerStateCopyWithImpl<$Res, _$_ResizerState>
-    implements _$$_ResizerStateCopyWith<$Res> {
-  __$$_ResizerStateCopyWithImpl(
-      _$_ResizerState _value, $Res Function(_$_ResizerState) _then)
+class __$$ResizerStateImplCopyWithImpl<$Res>
+    extends _$ResizerStateCopyWithImpl<$Res, _$ResizerStateImpl>
+    implements _$$ResizerStateImplCopyWith<$Res> {
+  __$$ResizerStateImplCopyWithImpl(
+      _$ResizerStateImpl _value, $Res Function(_$ResizerStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -118,7 +118,7 @@ class __$$_ResizerStateCopyWithImpl<$Res>
     Object? wantedSize = null,
     Object? delta = null,
   }) {
-    return _then(_$_ResizerState(
+    return _then(_$ResizerStateImpl(
       resizing: null == resizing
           ? _value.resizing
           : resizing // ignore: cast_nullable_to_non_nullable
@@ -145,8 +145,8 @@ class __$$_ResizerStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ResizerState implements _ResizerState {
-  const _$_ResizerState(
+class _$ResizerStateImpl implements _ResizerState {
+  const _$ResizerStateImpl(
       {required this.resizing,
       required this.resizeEdge,
       required this.startSize,
@@ -173,7 +173,7 @@ class _$_ResizerState implements _ResizerState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResizerState &&
+            other is _$ResizerStateImpl &&
             (identical(other.resizing, resizing) ||
                 other.resizing == resizing) &&
             (identical(other.resizeEdge, resizeEdge) ||
@@ -192,8 +192,8 @@ class _$_ResizerState implements _ResizerState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResizerStateCopyWith<_$_ResizerState> get copyWith =>
-      __$$_ResizerStateCopyWithImpl<_$_ResizerState>(this, _$identity);
+  _$$ResizerStateImplCopyWith<_$ResizerStateImpl> get copyWith =>
+      __$$ResizerStateImplCopyWithImpl<_$ResizerStateImpl>(this, _$identity);
 }
 
 abstract class _ResizerState implements ResizerState {
@@ -202,7 +202,7 @@ abstract class _ResizerState implements ResizerState {
       required final ResizeEdge? resizeEdge,
       required final Size startSize,
       required final Size wantedSize,
-      required final Offset delta}) = _$_ResizerState;
+      required final Offset delta}) = _$ResizerStateImpl;
 
   @override
   bool get resizing;
@@ -216,6 +216,6 @@ abstract class _ResizerState implements ResizerState {
   Offset get delta;
   @override
   @JsonKey(ignore: true)
-  _$$_ResizerStateCopyWith<_$_ResizerState> get copyWith =>
+  _$$ResizerStateImplCopyWith<_$ResizerStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_resize_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_resize_provider.g.dart
@@ -84,8 +84,8 @@ class WindowResizeProvider
     extends NotifierProviderImpl<WindowResize, ResizerState> {
   /// See also [WindowResize].
   WindowResizeProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => WindowResize()..viewId = viewId,
           from: windowResizeProvider,
           name: r'windowResizeProvider',
@@ -96,9 +96,50 @@ class WindowResizeProvider
           dependencies: WindowResizeFamily._dependencies,
           allTransitiveDependencies:
               WindowResizeFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  WindowResizeProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  ResizerState runNotifierBuild(
+    covariant WindowResize notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(WindowResize Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: WindowResizeProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<WindowResize, ResizerState> createElement() {
+    return _WindowResizeProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -112,14 +153,20 @@ class WindowResizeProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin WindowResizeRef on NotifierProviderRef<ResizerState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _WindowResizeProviderElement
+    extends NotifierProviderElement<WindowResize, ResizerState>
+    with WindowResizeRef {
+  _WindowResizeProviderElement(super.provider);
 
   @override
-  ResizerState runNotifierBuild(
-    covariant WindowResize notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as WindowResizeProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_stack_provider.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_stack_provider.freezed.dart
@@ -69,22 +69,22 @@ class _$WindowStackStateCopyWithImpl<$Res, $Val extends WindowStackState>
 }
 
 /// @nodoc
-abstract class _$$_WindowStackStateCopyWith<$Res>
+abstract class _$$WindowStackStateImplCopyWith<$Res>
     implements $WindowStackStateCopyWith<$Res> {
-  factory _$$_WindowStackStateCopyWith(
-          _$_WindowStackState value, $Res Function(_$_WindowStackState) then) =
-      __$$_WindowStackStateCopyWithImpl<$Res>;
+  factory _$$WindowStackStateImplCopyWith(_$WindowStackStateImpl value,
+          $Res Function(_$WindowStackStateImpl) then) =
+      __$$WindowStackStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({IList<int> stack, ISet<int> animateClosing, Size desktopSize});
 }
 
 /// @nodoc
-class __$$_WindowStackStateCopyWithImpl<$Res>
-    extends _$WindowStackStateCopyWithImpl<$Res, _$_WindowStackState>
-    implements _$$_WindowStackStateCopyWith<$Res> {
-  __$$_WindowStackStateCopyWithImpl(
-      _$_WindowStackState _value, $Res Function(_$_WindowStackState) _then)
+class __$$WindowStackStateImplCopyWithImpl<$Res>
+    extends _$WindowStackStateCopyWithImpl<$Res, _$WindowStackStateImpl>
+    implements _$$WindowStackStateImplCopyWith<$Res> {
+  __$$WindowStackStateImplCopyWithImpl(_$WindowStackStateImpl _value,
+      $Res Function(_$WindowStackStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -94,7 +94,7 @@ class __$$_WindowStackStateCopyWithImpl<$Res>
     Object? animateClosing = null,
     Object? desktopSize = null,
   }) {
-    return _then(_$_WindowStackState(
+    return _then(_$WindowStackStateImpl(
       stack: null == stack
           ? _value.stack
           : stack // ignore: cast_nullable_to_non_nullable
@@ -113,8 +113,8 @@ class __$$_WindowStackStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_WindowStackState extends _WindowStackState {
-  const _$_WindowStackState(
+class _$WindowStackStateImpl extends _WindowStackState {
+  const _$WindowStackStateImpl(
       {required this.stack,
       required this.animateClosing,
       required this.desktopSize})
@@ -136,7 +136,7 @@ class _$_WindowStackState extends _WindowStackState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_WindowStackState &&
+            other is _$WindowStackStateImpl &&
             const DeepCollectionEquality().equals(other.stack, stack) &&
             const DeepCollectionEquality()
                 .equals(other.animateClosing, animateClosing) &&
@@ -154,15 +154,16 @@ class _$_WindowStackState extends _WindowStackState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_WindowStackStateCopyWith<_$_WindowStackState> get copyWith =>
-      __$$_WindowStackStateCopyWithImpl<_$_WindowStackState>(this, _$identity);
+  _$$WindowStackStateImplCopyWith<_$WindowStackStateImpl> get copyWith =>
+      __$$WindowStackStateImplCopyWithImpl<_$WindowStackStateImpl>(
+          this, _$identity);
 }
 
 abstract class _WindowStackState extends WindowStackState {
   const factory _WindowStackState(
       {required final IList<int> stack,
       required final ISet<int> animateClosing,
-      required final Size desktopSize}) = _$_WindowStackState;
+      required final Size desktopSize}) = _$WindowStackStateImpl;
   const _WindowStackState._() : super._();
 
   @override
@@ -173,6 +174,6 @@ abstract class _WindowStackState extends WindowStackState {
   Size get desktopSize;
   @override
   @JsonKey(ignore: true)
-  _$$_WindowStackStateCopyWith<_$_WindowStackState> get copyWith =>
+  _$$WindowStackStateImplCopyWith<_$WindowStackStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_stack_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_stack_provider.g.dart
@@ -21,4 +21,5 @@ final windowStackProvider =
 );
 
 typedef _$WindowStack = Notifier<WindowStackState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_state_provider.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_state_provider.freezed.dart
@@ -73,11 +73,11 @@ class _$WindowProviderStateCopyWithImpl<$Res, $Val extends WindowProviderState>
 }
 
 /// @nodoc
-abstract class _$$_WindowProviderStateCopyWith<$Res>
+abstract class _$$WindowProviderStateImplCopyWith<$Res>
     implements $WindowProviderStateCopyWith<$Res> {
-  factory _$$_WindowProviderStateCopyWith(_$_WindowProviderState value,
-          $Res Function(_$_WindowProviderState) then) =
-      __$$_WindowProviderStateCopyWithImpl<$Res>;
+  factory _$$WindowProviderStateImplCopyWith(_$WindowProviderStateImpl value,
+          $Res Function(_$WindowProviderStateImpl) then) =
+      __$$WindowProviderStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -87,11 +87,11 @@ abstract class _$$_WindowProviderStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_WindowProviderStateCopyWithImpl<$Res>
-    extends _$WindowProviderStateCopyWithImpl<$Res, _$_WindowProviderState>
-    implements _$$_WindowProviderStateCopyWith<$Res> {
-  __$$_WindowProviderStateCopyWithImpl(_$_WindowProviderState _value,
-      $Res Function(_$_WindowProviderState) _then)
+class __$$WindowProviderStateImplCopyWithImpl<$Res>
+    extends _$WindowProviderStateCopyWithImpl<$Res, _$WindowProviderStateImpl>
+    implements _$$WindowProviderStateImplCopyWith<$Res> {
+  __$$WindowProviderStateImplCopyWithImpl(_$WindowProviderStateImpl _value,
+      $Res Function(_$WindowProviderStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -101,7 +101,7 @@ class __$$_WindowProviderStateCopyWithImpl<$Res>
     Object? repaintBoundaryKey = null,
     Object? snapshot = freezed,
   }) {
-    return _then(_$_WindowProviderState(
+    return _then(_$WindowProviderStateImpl(
       tiling: null == tiling
           ? _value.tiling
           : tiling // ignore: cast_nullable_to_non_nullable
@@ -120,8 +120,8 @@ class __$$_WindowProviderStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_WindowProviderState implements _WindowProviderState {
-  const _$_WindowProviderState(
+class _$WindowProviderStateImpl implements _WindowProviderState {
+  const _$WindowProviderStateImpl(
       {required this.tiling,
       required this.repaintBoundaryKey,
       required this.snapshot});
@@ -142,7 +142,7 @@ class _$_WindowProviderState implements _WindowProviderState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_WindowProviderState &&
+            other is _$WindowProviderStateImpl &&
             (identical(other.tiling, tiling) || other.tiling == tiling) &&
             (identical(other.repaintBoundaryKey, repaintBoundaryKey) ||
                 other.repaintBoundaryKey == repaintBoundaryKey) &&
@@ -157,8 +157,8 @@ class _$_WindowProviderState implements _WindowProviderState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_WindowProviderStateCopyWith<_$_WindowProviderState> get copyWith =>
-      __$$_WindowProviderStateCopyWithImpl<_$_WindowProviderState>(
+  _$$WindowProviderStateImplCopyWith<_$WindowProviderStateImpl> get copyWith =>
+      __$$WindowProviderStateImplCopyWithImpl<_$WindowProviderStateImpl>(
           this, _$identity);
 }
 
@@ -166,7 +166,7 @@ abstract class _WindowProviderState implements WindowProviderState {
   const factory _WindowProviderState(
       {required final Tiling tiling,
       required final GlobalKey<State<StatefulWidget>> repaintBoundaryKey,
-      required final ui.Image? snapshot}) = _$_WindowProviderState;
+      required final ui.Image? snapshot}) = _$WindowProviderStateImpl;
 
   @override
   Tiling get tiling;
@@ -176,6 +176,6 @@ abstract class _WindowProviderState implements WindowProviderState {
   ui.Image? get snapshot;
   @override
   @JsonKey(ignore: true)
-  _$$_WindowProviderStateCopyWith<_$_WindowProviderState> get copyWith =>
+  _$$WindowProviderStateImplCopyWith<_$WindowProviderStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/desktop/state/window_state_provider.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/state/window_state_provider.g.dart
@@ -6,7 +6,7 @@ part of '../../../../ui/desktop/state/window_state_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$windowStateHash() => r'63e0a621cfca1654e28ff7b9181f76188624673e';
+String _$windowStateHash() => r'385539b0f91dc3e85fc66c834b5e5c399b64ff5b';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -84,8 +84,8 @@ class WindowStateProvider
     extends NotifierProviderImpl<WindowState, WindowProviderState> {
   /// See also [WindowState].
   WindowStateProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => WindowState()..viewId = viewId,
           from: windowStateProvider,
           name: r'windowStateProvider',
@@ -96,9 +96,50 @@ class WindowStateProvider
           dependencies: WindowStateFamily._dependencies,
           allTransitiveDependencies:
               WindowStateFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  WindowStateProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  WindowProviderState runNotifierBuild(
+    covariant WindowState notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(WindowState Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: WindowStateProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<WindowState, WindowProviderState> createElement() {
+    return _WindowStateProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -112,14 +153,20 @@ class WindowStateProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin WindowStateRef on NotifierProviderRef<WindowProviderState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _WindowStateProviderElement
+    extends NotifierProviderElement<WindowState, WindowProviderState>
+    with WindowStateRef {
+  _WindowStateProviderElement(super.provider);
 
   @override
-  WindowProviderState runNotifierBuild(
-    covariant WindowState notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as WindowStateProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/task_bar.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/task_bar.g.dart
@@ -21,4 +21,5 @@ final taskBarHeightProvider = Provider<double>.internal(
 );
 
 typedef TaskBarHeightRef = ProviderRef<double>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/window.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/window.g.dart
@@ -29,8 +29,6 @@ class _SystemHash {
   }
 }
 
-typedef WindowWidgetRef = ProviderRef<Window>;
-
 /// See also [windowWidget].
 @ProviderFor(windowWidget)
 const windowWidgetProvider = WindowWidgetFamily();
@@ -77,10 +75,10 @@ class WindowWidgetFamily extends Family<Window> {
 class WindowWidgetProvider extends Provider<Window> {
   /// See also [windowWidget].
   WindowWidgetProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => windowWidget(
-            ref,
+            ref as WindowWidgetRef,
             viewId,
           ),
           from: windowWidgetProvider,
@@ -92,9 +90,43 @@ class WindowWidgetProvider extends Provider<Window> {
           dependencies: WindowWidgetFamily._dependencies,
           allTransitiveDependencies:
               WindowWidgetFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  WindowWidgetProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    Window Function(WindowWidgetRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: WindowWidgetProvider._internal(
+        (ref) => create(ref as WindowWidgetRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<Window> createElement() {
+    return _WindowWidgetProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -109,4 +141,18 @@ class WindowWidgetProvider extends Provider<Window> {
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+
+mixin WindowWidgetRef on ProviderRef<Window> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _WindowWidgetProviderElement extends ProviderElement<Window>
+    with WindowWidgetRef {
+  _WindowWidgetProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as WindowWidgetProvider).viewId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/desktop/window_manager.g.dart
+++ b/veshell_flutter/lib/generated/ui/desktop/window_manager.g.dart
@@ -11,8 +11,7 @@ String _$windowStackGlobalKeyHash() =>
 
 /// See also [windowStackGlobalKey].
 @ProviderFor(windowStackGlobalKey)
-final windowStackGlobalKeyProvider =
-    Provider<GlobalKey<State<StatefulWidget>>>.internal(
+final windowStackGlobalKeyProvider = Provider<GlobalKey>.internal(
   windowStackGlobalKey,
   name: r'windowStackGlobalKeyProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -22,5 +21,6 @@ final windowStackGlobalKeyProvider =
   allTransitiveDependencies: null,
 );
 
-typedef WindowStackGlobalKeyRef = ProviderRef<GlobalKey<State<StatefulWidget>>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+typedef WindowStackGlobalKeyRef = ProviderRef<GlobalKey>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/app_drawer/app_grid.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/app_drawer/app_grid.g.dart
@@ -20,4 +20,5 @@ final _appWidgetsProvider = FutureProvider<List<AppEntry>>.internal(
 );
 
 typedef _AppWidgetsRef = FutureProviderRef<List<AppEntry>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/lock_screen.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/lock_screen.g.dart
@@ -22,4 +22,5 @@ final _authErrorMessageProvider =
 );
 
 typedef _$AuthErrorMessage = Notifier<String>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/state/app_drawer_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/app_drawer_state.freezed.dart
@@ -104,11 +104,11 @@ class _$AppDrawerStateCopyWithImpl<$Res, $Val extends AppDrawerState>
 }
 
 /// @nodoc
-abstract class _$$_AppDrawerStateCopyWith<$Res>
+abstract class _$$AppDrawerStateImplCopyWith<$Res>
     implements $AppDrawerStateCopyWith<$Res> {
-  factory _$$_AppDrawerStateCopyWith(
-          _$_AppDrawerState value, $Res Function(_$_AppDrawerState) then) =
-      __$$_AppDrawerStateCopyWithImpl<$Res>;
+  factory _$$AppDrawerStateImplCopyWith(_$AppDrawerStateImpl value,
+          $Res Function(_$AppDrawerStateImpl) then) =
+      __$$AppDrawerStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -123,11 +123,11 @@ abstract class _$$_AppDrawerStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AppDrawerStateCopyWithImpl<$Res>
-    extends _$AppDrawerStateCopyWithImpl<$Res, _$_AppDrawerState>
-    implements _$$_AppDrawerStateCopyWith<$Res> {
-  __$$_AppDrawerStateCopyWithImpl(
-      _$_AppDrawerState _value, $Res Function(_$_AppDrawerState) _then)
+class __$$AppDrawerStateImplCopyWithImpl<$Res>
+    extends _$AppDrawerStateCopyWithImpl<$Res, _$AppDrawerStateImpl>
+    implements _$$AppDrawerStateImplCopyWith<$Res> {
+  __$$AppDrawerStateImplCopyWithImpl(
+      _$AppDrawerStateImpl _value, $Res Function(_$AppDrawerStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -142,7 +142,7 @@ class __$$_AppDrawerStateCopyWithImpl<$Res>
     Object? closePanel = null,
     Object? fullyClosed = null,
   }) {
-    return _then(_$_AppDrawerState(
+    return _then(_$AppDrawerStateImpl(
       draggable: null == draggable
           ? _value.draggable
           : draggable // ignore: cast_nullable_to_non_nullable
@@ -178,8 +178,8 @@ class __$$_AppDrawerStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_AppDrawerState implements _AppDrawerState {
-  const _$_AppDrawerState(
+class _$AppDrawerStateImpl implements _AppDrawerState {
+  const _$AppDrawerStateImpl(
       {required this.draggable,
       required this.dragging,
       required this.interactable,
@@ -215,7 +215,7 @@ class _$_AppDrawerState implements _AppDrawerState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AppDrawerState &&
+            other is _$AppDrawerStateImpl &&
             (identical(other.draggable, draggable) ||
                 other.draggable == draggable) &&
             (identical(other.dragging, dragging) ||
@@ -248,8 +248,9 @@ class _$_AppDrawerState implements _AppDrawerState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AppDrawerStateCopyWith<_$_AppDrawerState> get copyWith =>
-      __$$_AppDrawerStateCopyWithImpl<_$_AppDrawerState>(this, _$identity);
+  _$$AppDrawerStateImplCopyWith<_$AppDrawerStateImpl> get copyWith =>
+      __$$AppDrawerStateImplCopyWithImpl<_$AppDrawerStateImpl>(
+          this, _$identity);
 }
 
 abstract class _AppDrawerState implements AppDrawerState {
@@ -261,7 +262,7 @@ abstract class _AppDrawerState implements AppDrawerState {
       required final double offset,
       required final double slideDistance,
       required final Object closePanel,
-      required final bool fullyClosed}) = _$_AppDrawerState;
+      required final bool fullyClosed}) = _$AppDrawerStateImpl;
 
   @override
   bool get draggable;
@@ -281,6 +282,6 @@ abstract class _AppDrawerState implements AppDrawerState {
   bool get fullyClosed;
   @override
   @JsonKey(ignore: true)
-  _$$_AppDrawerStateCopyWith<_$_AppDrawerState> get copyWith =>
+  _$$AppDrawerStateImplCopyWith<_$AppDrawerStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/mobile/state/app_drawer_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/app_drawer_state.g.dart
@@ -22,4 +22,5 @@ final appDrawerNotifierProvider =
 );
 
 typedef _$AppDrawerNotifier = Notifier<AppDrawerState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/state/mobile_lock_screen_widget_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/mobile_lock_screen_widget_state.freezed.dart
@@ -96,12 +96,12 @@ class _$MobileLockScreenWidgetStateCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MobileLockScreenWidgetStateCopyWith<$Res>
+abstract class _$$MobileLockScreenWidgetStateImplCopyWith<$Res>
     implements $MobileLockScreenWidgetStateCopyWith<$Res> {
-  factory _$$_MobileLockScreenWidgetStateCopyWith(
-          _$_MobileLockScreenWidgetState value,
-          $Res Function(_$_MobileLockScreenWidgetState) then) =
-      __$$_MobileLockScreenWidgetStateCopyWithImpl<$Res>;
+  factory _$$MobileLockScreenWidgetStateImplCopyWith(
+          _$MobileLockScreenWidgetStateImpl value,
+          $Res Function(_$MobileLockScreenWidgetStateImpl) then) =
+      __$$MobileLockScreenWidgetStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -114,13 +114,13 @@ abstract class _$$_MobileLockScreenWidgetStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_MobileLockScreenWidgetStateCopyWithImpl<$Res>
+class __$$MobileLockScreenWidgetStateImplCopyWithImpl<$Res>
     extends _$MobileLockScreenWidgetStateCopyWithImpl<$Res,
-        _$_MobileLockScreenWidgetState>
-    implements _$$_MobileLockScreenWidgetStateCopyWith<$Res> {
-  __$$_MobileLockScreenWidgetStateCopyWithImpl(
-      _$_MobileLockScreenWidgetState _value,
-      $Res Function(_$_MobileLockScreenWidgetState) _then)
+        _$MobileLockScreenWidgetStateImpl>
+    implements _$$MobileLockScreenWidgetStateImplCopyWith<$Res> {
+  __$$MobileLockScreenWidgetStateImplCopyWithImpl(
+      _$MobileLockScreenWidgetStateImpl _value,
+      $Res Function(_$MobileLockScreenWidgetStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_MobileLockScreenWidgetStateCopyWithImpl<$Res>
     Object? offset = null,
     Object? slideDistance = null,
   }) {
-    return _then(_$_MobileLockScreenWidgetState(
+    return _then(_$MobileLockScreenWidgetStateImpl(
       overlayEntry: null == overlayEntry
           ? _value.overlayEntry
           : overlayEntry // ignore: cast_nullable_to_non_nullable
@@ -164,8 +164,9 @@ class __$$_MobileLockScreenWidgetStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_MobileLockScreenWidgetState implements _MobileLockScreenWidgetState {
-  const _$_MobileLockScreenWidgetState(
+class _$MobileLockScreenWidgetStateImpl
+    implements _MobileLockScreenWidgetState {
+  const _$MobileLockScreenWidgetStateImpl(
       {required this.overlayEntry,
       required this.overlayEntryInserted,
       required this.dragging,
@@ -195,7 +196,7 @@ class _$_MobileLockScreenWidgetState implements _MobileLockScreenWidgetState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MobileLockScreenWidgetState &&
+            other is _$MobileLockScreenWidgetStateImpl &&
             (identical(other.overlayEntry, overlayEntry) ||
                 other.overlayEntry == overlayEntry) &&
             (identical(other.overlayEntryInserted, overlayEntryInserted) ||
@@ -216,9 +217,9 @@ class _$_MobileLockScreenWidgetState implements _MobileLockScreenWidgetState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MobileLockScreenWidgetStateCopyWith<_$_MobileLockScreenWidgetState>
-      get copyWith => __$$_MobileLockScreenWidgetStateCopyWithImpl<
-          _$_MobileLockScreenWidgetState>(this, _$identity);
+  _$$MobileLockScreenWidgetStateImplCopyWith<_$MobileLockScreenWidgetStateImpl>
+      get copyWith => __$$MobileLockScreenWidgetStateImplCopyWithImpl<
+          _$MobileLockScreenWidgetStateImpl>(this, _$identity);
 }
 
 abstract class _MobileLockScreenWidgetState
@@ -229,7 +230,7 @@ abstract class _MobileLockScreenWidgetState
       required final bool dragging,
       required final double dragVelocity,
       required final double offset,
-      required final double slideDistance}) = _$_MobileLockScreenWidgetState;
+      required final double slideDistance}) = _$MobileLockScreenWidgetStateImpl;
 
   @override
   OverlayEntry get overlayEntry;
@@ -245,6 +246,6 @@ abstract class _MobileLockScreenWidgetState
   double get slideDistance;
   @override
   @JsonKey(ignore: true)
-  _$$_MobileLockScreenWidgetStateCopyWith<_$_MobileLockScreenWidgetState>
+  _$$MobileLockScreenWidgetStateImplCopyWith<_$MobileLockScreenWidgetStateImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/mobile/state/mobile_lock_screen_widget_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/mobile_lock_screen_widget_state.g.dart
@@ -23,4 +23,5 @@ final mobileLockScreenStateProvider = NotifierProvider<MobileLockScreenState,
 );
 
 typedef _$MobileLockScreenState = Notifier<MobileLockScreenWidgetState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/state/power_menu_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/power_menu_state.freezed.dart
@@ -80,11 +80,11 @@ class _$PowerMenuStateCopyWithImpl<$Res, $Val extends PowerMenuState>
 }
 
 /// @nodoc
-abstract class _$$_PowerMenuStateCopyWith<$Res>
+abstract class _$$PowerMenuStateImplCopyWith<$Res>
     implements $PowerMenuStateCopyWith<$Res> {
-  factory _$$_PowerMenuStateCopyWith(
-          _$_PowerMenuState value, $Res Function(_$_PowerMenuState) then) =
-      __$$_PowerMenuStateCopyWithImpl<$Res>;
+  factory _$$PowerMenuStateImplCopyWith(_$PowerMenuStateImpl value,
+          $Res Function(_$PowerMenuStateImpl) then) =
+      __$$PowerMenuStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -96,11 +96,11 @@ abstract class _$$_PowerMenuStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PowerMenuStateCopyWithImpl<$Res>
-    extends _$PowerMenuStateCopyWithImpl<$Res, _$_PowerMenuState>
-    implements _$$_PowerMenuStateCopyWith<$Res> {
-  __$$_PowerMenuStateCopyWithImpl(
-      _$_PowerMenuState _value, $Res Function(_$_PowerMenuState) _then)
+class __$$PowerMenuStateImplCopyWithImpl<$Res>
+    extends _$PowerMenuStateCopyWithImpl<$Res, _$PowerMenuStateImpl>
+    implements _$$PowerMenuStateImplCopyWith<$Res> {
+  __$$PowerMenuStateImplCopyWithImpl(
+      _$PowerMenuStateImpl _value, $Res Function(_$PowerMenuStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -112,7 +112,7 @@ class __$$_PowerMenuStateCopyWithImpl<$Res>
     Object? show = null,
     Object? hide = null,
   }) {
-    return _then(_$_PowerMenuState(
+    return _then(_$PowerMenuStateImpl(
       overlayEntry: null == overlayEntry
           ? _value.overlayEntry
           : overlayEntry // ignore: cast_nullable_to_non_nullable
@@ -133,8 +133,8 @@ class __$$_PowerMenuStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_PowerMenuState implements _PowerMenuState {
-  const _$_PowerMenuState(
+class _$PowerMenuStateImpl implements _PowerMenuState {
+  const _$PowerMenuStateImpl(
       {required this.overlayEntry,
       required this.overlayEntryInserted,
       required this.shown,
@@ -161,7 +161,7 @@ class _$_PowerMenuState implements _PowerMenuState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PowerMenuState &&
+            other is _$PowerMenuStateImpl &&
             (identical(other.overlayEntry, overlayEntry) ||
                 other.overlayEntry == overlayEntry) &&
             (identical(other.overlayEntryInserted, overlayEntryInserted) ||
@@ -183,8 +183,9 @@ class _$_PowerMenuState implements _PowerMenuState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PowerMenuStateCopyWith<_$_PowerMenuState> get copyWith =>
-      __$$_PowerMenuStateCopyWithImpl<_$_PowerMenuState>(this, _$identity);
+  _$$PowerMenuStateImplCopyWith<_$PowerMenuStateImpl> get copyWith =>
+      __$$PowerMenuStateImplCopyWithImpl<_$PowerMenuStateImpl>(
+          this, _$identity);
 }
 
 abstract class _PowerMenuState implements PowerMenuState {
@@ -193,7 +194,7 @@ abstract class _PowerMenuState implements PowerMenuState {
       required final bool overlayEntryInserted,
       required final bool shown,
       required final Object show,
-      required final Object hide}) = _$_PowerMenuState;
+      required final Object hide}) = _$PowerMenuStateImpl;
 
   @override
   OverlayEntry get overlayEntry;
@@ -207,6 +208,6 @@ abstract class _PowerMenuState implements PowerMenuState {
   Object get hide;
   @override
   @JsonKey(ignore: true)
-  _$$_PowerMenuStateCopyWith<_$_PowerMenuState> get copyWith =>
+  _$$PowerMenuStateImplCopyWith<_$PowerMenuStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/mobile/state/power_menu_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/power_menu_state.g.dart
@@ -23,4 +23,5 @@ final powerMenuStateNotifierProvider =
 );
 
 typedef _$PowerMenuStateNotifier = Notifier<PowerMenuState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/state/task_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/task_state.freezed.dart
@@ -69,10 +69,11 @@ class _$TaskStateCopyWithImpl<$Res, $Val extends TaskState>
 }
 
 /// @nodoc
-abstract class _$$_TaskStateCopyWith<$Res> implements $TaskStateCopyWith<$Res> {
-  factory _$$_TaskStateCopyWith(
-          _$_TaskState value, $Res Function(_$_TaskState) then) =
-      __$$_TaskStateCopyWithImpl<$Res>;
+abstract class _$$TaskStateImplCopyWith<$Res>
+    implements $TaskStateCopyWith<$Res> {
+  factory _$$TaskStateImplCopyWith(
+          _$TaskStateImpl value, $Res Function(_$TaskStateImpl) then) =
+      __$$TaskStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -82,11 +83,11 @@ abstract class _$$_TaskStateCopyWith<$Res> implements $TaskStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TaskStateCopyWithImpl<$Res>
-    extends _$TaskStateCopyWithImpl<$Res, _$_TaskState>
-    implements _$$_TaskStateCopyWith<$Res> {
-  __$$_TaskStateCopyWithImpl(
-      _$_TaskState _value, $Res Function(_$_TaskState) _then)
+class __$$TaskStateImplCopyWithImpl<$Res>
+    extends _$TaskStateCopyWithImpl<$Res, _$TaskStateImpl>
+    implements _$$TaskStateImplCopyWith<$Res> {
+  __$$TaskStateImplCopyWithImpl(
+      _$TaskStateImpl _value, $Res Function(_$TaskStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -96,7 +97,7 @@ class __$$_TaskStateCopyWithImpl<$Res>
     Object? startDismissAnimation = null,
     Object? cancelDismissAnimation = null,
   }) {
-    return _then(_$_TaskState(
+    return _then(_$TaskStateImpl(
       dismissState: null == dismissState
           ? _value.dismissState
           : dismissState // ignore: cast_nullable_to_non_nullable
@@ -113,8 +114,8 @@ class __$$_TaskStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_TaskState implements _TaskState {
-  const _$_TaskState(
+class _$TaskStateImpl implements _TaskState {
+  const _$TaskStateImpl(
       {required this.dismissState,
       required this.startDismissAnimation,
       required this.cancelDismissAnimation});
@@ -135,7 +136,7 @@ class _$_TaskState implements _TaskState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TaskState &&
+            other is _$TaskStateImpl &&
             (identical(other.dismissState, dismissState) ||
                 other.dismissState == dismissState) &&
             const DeepCollectionEquality()
@@ -154,15 +155,15 @@ class _$_TaskState implements _TaskState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TaskStateCopyWith<_$_TaskState> get copyWith =>
-      __$$_TaskStateCopyWithImpl<_$_TaskState>(this, _$identity);
+  _$$TaskStateImplCopyWith<_$TaskStateImpl> get copyWith =>
+      __$$TaskStateImplCopyWithImpl<_$TaskStateImpl>(this, _$identity);
 }
 
 abstract class _TaskState implements TaskState {
   const factory _TaskState(
       {required final TaskDismissState dismissState,
       required final Object startDismissAnimation,
-      required final Object cancelDismissAnimation}) = _$_TaskState;
+      required final Object cancelDismissAnimation}) = _$TaskStateImpl;
 
   @override
   TaskDismissState get dismissState;
@@ -172,6 +173,6 @@ abstract class _TaskState implements TaskState {
   Object get cancelDismissAnimation;
   @override
   @JsonKey(ignore: true)
-  _$$_TaskStateCopyWith<_$_TaskState> get copyWith =>
+  _$$TaskStateImplCopyWith<_$TaskStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/mobile/state/task_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/task_state.g.dart
@@ -29,8 +29,6 @@ class _SystemHash {
   }
 }
 
-typedef TaskWidgetRef = ProviderRef<Task>;
-
 /// See also [taskWidget].
 @ProviderFor(taskWidget)
 const taskWidgetProvider = TaskWidgetFamily();
@@ -77,10 +75,10 @@ class TaskWidgetFamily extends Family<Task> {
 class TaskWidgetProvider extends Provider<Task> {
   /// See also [taskWidget].
   TaskWidgetProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           (ref) => taskWidget(
-            ref,
+            ref as TaskWidgetRef,
             viewId,
           ),
           from: taskWidgetProvider,
@@ -92,9 +90,43 @@ class TaskWidgetProvider extends Provider<Task> {
           dependencies: TaskWidgetFamily._dependencies,
           allTransitiveDependencies:
               TaskWidgetFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  TaskWidgetProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Override overrideWith(
+    Task Function(TaskWidgetRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: TaskWidgetProvider._internal(
+        (ref) => create(ref as TaskWidgetRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<Task> createElement() {
+    return _TaskWidgetProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -108,6 +140,19 @@ class TaskWidgetProvider extends Provider<Task> {
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin TaskWidgetRef on ProviderRef<Task> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _TaskWidgetProviderElement extends ProviderElement<Task>
+    with TaskWidgetRef {
+  _TaskWidgetProviderElement(super.provider);
+
+  @override
+  int get viewId => (origin as TaskWidgetProvider).viewId;
 }
 
 String _$taskStateNotifierHash() => r'e471d5b2f87ec17f9d4ea2786d580abc3cf1b0c2';
@@ -167,8 +212,8 @@ class TaskStateNotifierProvider
     extends NotifierProviderImpl<TaskStateNotifier, TaskState> {
   /// See also [TaskStateNotifier].
   TaskStateNotifierProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => TaskStateNotifier()..viewId = viewId,
           from: taskStateNotifierProvider,
           name: r'taskStateNotifierProvider',
@@ -179,9 +224,50 @@ class TaskStateNotifierProvider
           dependencies: TaskStateNotifierFamily._dependencies,
           allTransitiveDependencies:
               TaskStateNotifierFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  TaskStateNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  TaskState runNotifierBuild(
+    covariant TaskStateNotifier notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(TaskStateNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: TaskStateNotifierProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<TaskStateNotifier, TaskState> createElement() {
+    return _TaskStateNotifierProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -195,15 +281,20 @@ class TaskStateNotifierProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin TaskStateNotifierRef on NotifierProviderRef<TaskState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _TaskStateNotifierProviderElement
+    extends NotifierProviderElement<TaskStateNotifier, TaskState>
+    with TaskStateNotifierRef {
+  _TaskStateNotifierProviderElement(super.provider);
 
   @override
-  TaskState runNotifierBuild(
-    covariant TaskStateNotifier notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as TaskStateNotifierProvider).viewId;
 }
 
 String _$taskPositionHash() => r'8b1381e2330cded890010168c7cfb8846211ce09';
@@ -262,8 +353,8 @@ class TaskPositionFamily extends Family<double> {
 class TaskPositionProvider extends NotifierProviderImpl<TaskPosition, double> {
   /// See also [TaskPosition].
   TaskPositionProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => TaskPosition()..viewId = viewId,
           from: taskPositionProvider,
           name: r'taskPositionProvider',
@@ -274,9 +365,50 @@ class TaskPositionProvider extends NotifierProviderImpl<TaskPosition, double> {
           dependencies: TaskPositionFamily._dependencies,
           allTransitiveDependencies:
               TaskPositionFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  TaskPositionProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  double runNotifierBuild(
+    covariant TaskPosition notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(TaskPosition Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: TaskPositionProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<TaskPosition, double> createElement() {
+    return _TaskPositionProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -290,15 +422,19 @@ class TaskPositionProvider extends NotifierProviderImpl<TaskPosition, double> {
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin TaskPositionRef on NotifierProviderRef<double> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _TaskPositionProviderElement
+    extends NotifierProviderElement<TaskPosition, double> with TaskPositionRef {
+  _TaskPositionProviderElement(super.provider);
 
   @override
-  double runNotifierBuild(
-    covariant TaskPosition notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as TaskPositionProvider).viewId;
 }
 
 String _$taskVerticalPositionHash() =>
@@ -359,8 +495,8 @@ class TaskVerticalPositionProvider
     extends NotifierProviderImpl<TaskVerticalPosition, double> {
   /// See also [TaskVerticalPosition].
   TaskVerticalPositionProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => TaskVerticalPosition()..viewId = viewId,
           from: taskVerticalPositionProvider,
           name: r'taskVerticalPositionProvider',
@@ -371,9 +507,50 @@ class TaskVerticalPositionProvider
           dependencies: TaskVerticalPositionFamily._dependencies,
           allTransitiveDependencies:
               TaskVerticalPositionFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  TaskVerticalPositionProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  double runNotifierBuild(
+    covariant TaskVerticalPosition notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(TaskVerticalPosition Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: TaskVerticalPositionProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<TaskVerticalPosition, double> createElement() {
+    return _TaskVerticalPositionProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -387,14 +564,20 @@ class TaskVerticalPositionProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin TaskVerticalPositionRef on NotifierProviderRef<double> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _TaskVerticalPositionProviderElement
+    extends NotifierProviderElement<TaskVerticalPosition, double>
+    with TaskVerticalPositionRef {
+  _TaskVerticalPositionProviderElement(super.provider);
 
   @override
-  double runNotifierBuild(
-    covariant TaskVerticalPosition notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as TaskVerticalPositionProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/state/task_switcher_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/task_switcher_state.freezed.dart
@@ -86,11 +86,11 @@ class _$TaskSwitcherStateCopyWithImpl<$Res, $Val extends TaskSwitcherState>
 }
 
 /// @nodoc
-abstract class _$$_TaskSwitcherStateCopyWith<$Res>
+abstract class _$$TaskSwitcherStateImplCopyWith<$Res>
     implements $TaskSwitcherStateCopyWith<$Res> {
-  factory _$$_TaskSwitcherStateCopyWith(_$_TaskSwitcherState value,
-          $Res Function(_$_TaskSwitcherState) then) =
-      __$$_TaskSwitcherStateCopyWithImpl<$Res>;
+  factory _$$TaskSwitcherStateImplCopyWith(_$TaskSwitcherStateImpl value,
+          $Res Function(_$TaskSwitcherStateImpl) then) =
+      __$$TaskSwitcherStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -102,11 +102,11 @@ abstract class _$$_TaskSwitcherStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_TaskSwitcherStateCopyWithImpl<$Res>
-    extends _$TaskSwitcherStateCopyWithImpl<$Res, _$_TaskSwitcherState>
-    implements _$$_TaskSwitcherStateCopyWith<$Res> {
-  __$$_TaskSwitcherStateCopyWithImpl(
-      _$_TaskSwitcherState _value, $Res Function(_$_TaskSwitcherState) _then)
+class __$$TaskSwitcherStateImplCopyWithImpl<$Res>
+    extends _$TaskSwitcherStateCopyWithImpl<$Res, _$TaskSwitcherStateImpl>
+    implements _$$TaskSwitcherStateImplCopyWith<$Res> {
+  __$$TaskSwitcherStateImplCopyWithImpl(_$TaskSwitcherStateImpl _value,
+      $Res Function(_$TaskSwitcherStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -118,7 +118,7 @@ class __$$_TaskSwitcherStateCopyWithImpl<$Res>
     Object? areAnimationsPlaying = null,
     Object? constraintsChanged = null,
   }) {
-    return _then(_$_TaskSwitcherState(
+    return _then(_$TaskSwitcherStateImpl(
       inOverview: null == inOverview
           ? _value.inOverview
           : inOverview // ignore: cast_nullable_to_non_nullable
@@ -144,8 +144,8 @@ class __$$_TaskSwitcherStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_TaskSwitcherState implements _TaskSwitcherState {
-  _$_TaskSwitcherState(
+class _$TaskSwitcherStateImpl implements _TaskSwitcherState {
+  _$TaskSwitcherStateImpl(
       {required this.inOverview,
       required this.scale,
       required this.disableUserControl,
@@ -173,7 +173,7 @@ class _$_TaskSwitcherState implements _TaskSwitcherState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TaskSwitcherState &&
+            other is _$TaskSwitcherStateImpl &&
             (identical(other.inOverview, inOverview) ||
                 other.inOverview == inOverview) &&
             (identical(other.scale, scale) || other.scale == scale) &&
@@ -197,8 +197,8 @@ class _$_TaskSwitcherState implements _TaskSwitcherState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TaskSwitcherStateCopyWith<_$_TaskSwitcherState> get copyWith =>
-      __$$_TaskSwitcherStateCopyWithImpl<_$_TaskSwitcherState>(
+  _$$TaskSwitcherStateImplCopyWith<_$TaskSwitcherStateImpl> get copyWith =>
+      __$$TaskSwitcherStateImplCopyWithImpl<_$TaskSwitcherStateImpl>(
           this, _$identity);
 }
 
@@ -208,7 +208,7 @@ abstract class _TaskSwitcherState implements TaskSwitcherState {
       required final double scale,
       required final bool disableUserControl,
       required final bool areAnimationsPlaying,
-      required final Object constraintsChanged}) = _$_TaskSwitcherState;
+      required final Object constraintsChanged}) = _$TaskSwitcherStateImpl;
 
   @override
   bool get inOverview;
@@ -222,6 +222,6 @@ abstract class _TaskSwitcherState implements TaskSwitcherState {
   Object get constraintsChanged;
   @override
   @JsonKey(ignore: true)
-  _$$_TaskSwitcherStateCopyWith<_$_TaskSwitcherState> get copyWith =>
+  _$$TaskSwitcherStateImplCopyWith<_$TaskSwitcherStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/mobile/state/task_switcher_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/task_switcher_state.g.dart
@@ -23,4 +23,5 @@ final taskSwitcherStateNotifierProvider =
 );
 
 typedef _$TaskSwitcherStateNotifier = Notifier<TaskSwitcherState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/state/virtual_keyboard_state.freezed.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/virtual_keyboard_state.freezed.dart
@@ -64,22 +64,22 @@ class _$VirtualKeyboardStateCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_VirtualKeyboardStateCopyWith<$Res>
+abstract class _$$VirtualKeyboardStateImplCopyWith<$Res>
     implements $VirtualKeyboardStateCopyWith<$Res> {
-  factory _$$_VirtualKeyboardStateCopyWith(_$_VirtualKeyboardState value,
-          $Res Function(_$_VirtualKeyboardState) then) =
-      __$$_VirtualKeyboardStateCopyWithImpl<$Res>;
+  factory _$$VirtualKeyboardStateImplCopyWith(_$VirtualKeyboardStateImpl value,
+          $Res Function(_$VirtualKeyboardStateImpl) then) =
+      __$$VirtualKeyboardStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool activated, Size size});
 }
 
 /// @nodoc
-class __$$_VirtualKeyboardStateCopyWithImpl<$Res>
-    extends _$VirtualKeyboardStateCopyWithImpl<$Res, _$_VirtualKeyboardState>
-    implements _$$_VirtualKeyboardStateCopyWith<$Res> {
-  __$$_VirtualKeyboardStateCopyWithImpl(_$_VirtualKeyboardState _value,
-      $Res Function(_$_VirtualKeyboardState) _then)
+class __$$VirtualKeyboardStateImplCopyWithImpl<$Res>
+    extends _$VirtualKeyboardStateCopyWithImpl<$Res, _$VirtualKeyboardStateImpl>
+    implements _$$VirtualKeyboardStateImplCopyWith<$Res> {
+  __$$VirtualKeyboardStateImplCopyWithImpl(_$VirtualKeyboardStateImpl _value,
+      $Res Function(_$VirtualKeyboardStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -88,7 +88,7 @@ class __$$_VirtualKeyboardStateCopyWithImpl<$Res>
     Object? activated = null,
     Object? size = null,
   }) {
-    return _then(_$_VirtualKeyboardState(
+    return _then(_$VirtualKeyboardStateImpl(
       activated: null == activated
           ? _value.activated
           : activated // ignore: cast_nullable_to_non_nullable
@@ -103,8 +103,9 @@ class __$$_VirtualKeyboardStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_VirtualKeyboardState implements _VirtualKeyboardState {
-  const _$_VirtualKeyboardState({required this.activated, required this.size});
+class _$VirtualKeyboardStateImpl implements _VirtualKeyboardState {
+  const _$VirtualKeyboardStateImpl(
+      {required this.activated, required this.size});
 
   @override
   final bool activated;
@@ -120,7 +121,7 @@ class _$_VirtualKeyboardState implements _VirtualKeyboardState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_VirtualKeyboardState &&
+            other is _$VirtualKeyboardStateImpl &&
             (identical(other.activated, activated) ||
                 other.activated == activated) &&
             (identical(other.size, size) || other.size == size));
@@ -132,15 +133,16 @@ class _$_VirtualKeyboardState implements _VirtualKeyboardState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_VirtualKeyboardStateCopyWith<_$_VirtualKeyboardState> get copyWith =>
-      __$$_VirtualKeyboardStateCopyWithImpl<_$_VirtualKeyboardState>(
-          this, _$identity);
+  _$$VirtualKeyboardStateImplCopyWith<_$VirtualKeyboardStateImpl>
+      get copyWith =>
+          __$$VirtualKeyboardStateImplCopyWithImpl<_$VirtualKeyboardStateImpl>(
+              this, _$identity);
 }
 
 abstract class _VirtualKeyboardState implements VirtualKeyboardState {
   const factory _VirtualKeyboardState(
       {required final bool activated,
-      required final Size size}) = _$_VirtualKeyboardState;
+      required final Size size}) = _$VirtualKeyboardStateImpl;
 
   @override
   bool get activated;
@@ -148,6 +150,6 @@ abstract class _VirtualKeyboardState implements VirtualKeyboardState {
   Size get size;
   @override
   @JsonKey(ignore: true)
-  _$$_VirtualKeyboardStateCopyWith<_$_VirtualKeyboardState> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$VirtualKeyboardStateImplCopyWith<_$VirtualKeyboardStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/ui/mobile/state/virtual_keyboard_state.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/state/virtual_keyboard_state.g.dart
@@ -88,8 +88,8 @@ class VirtualKeyboardStateNotifierProvider
         VirtualKeyboardState> {
   /// See also [VirtualKeyboardStateNotifier].
   VirtualKeyboardStateNotifierProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => VirtualKeyboardStateNotifier()..viewId = viewId,
           from: virtualKeyboardStateNotifierProvider,
           name: r'virtualKeyboardStateNotifierProvider',
@@ -100,9 +100,51 @@ class VirtualKeyboardStateNotifierProvider
           dependencies: VirtualKeyboardStateNotifierFamily._dependencies,
           allTransitiveDependencies:
               VirtualKeyboardStateNotifierFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  VirtualKeyboardStateNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  VirtualKeyboardState runNotifierBuild(
+    covariant VirtualKeyboardStateNotifier notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(VirtualKeyboardStateNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: VirtualKeyboardStateNotifierProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<VirtualKeyboardStateNotifier,
+      VirtualKeyboardState> createElement() {
+    return _VirtualKeyboardStateNotifierProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -117,14 +159,21 @@ class VirtualKeyboardStateNotifierProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin VirtualKeyboardStateNotifierRef
+    on AutoDisposeNotifierProviderRef<VirtualKeyboardState> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _VirtualKeyboardStateNotifierProviderElement
+    extends AutoDisposeNotifierProviderElement<VirtualKeyboardStateNotifier,
+        VirtualKeyboardState> with VirtualKeyboardStateNotifierRef {
+  _VirtualKeyboardStateNotifierProviderElement(super.provider);
 
   @override
-  VirtualKeyboardState runNotifierBuild(
-    covariant VirtualKeyboardStateNotifier notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as VirtualKeyboardStateNotifierProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/task_switcher/task_switcher.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/task_switcher/task_switcher.g.dart
@@ -104,4 +104,5 @@ final _scrollPositionMaxScrollExtentProvider =
 );
 
 typedef _$ScrollPositionMaxScrollExtent = Notifier<double>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/ui/mobile/virtual_keyboard/virtual_keyboard.g.dart
+++ b/veshell_flutter/lib/generated/ui/mobile/virtual_keyboard/virtual_keyboard.g.dart
@@ -115,8 +115,8 @@ class KeyboardLayerProvider
     extends AutoDisposeNotifierProviderImpl<KeyboardLayer, KbLayerEnum> {
   /// See also [KeyboardLayer].
   KeyboardLayerProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => KeyboardLayer()..viewId = viewId,
           from: keyboardLayerProvider,
           name: r'keyboardLayerProvider',
@@ -127,9 +127,51 @@ class KeyboardLayerProvider
           dependencies: KeyboardLayerFamily._dependencies,
           allTransitiveDependencies:
               KeyboardLayerFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  KeyboardLayerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  KbLayerEnum runNotifierBuild(
+    covariant KeyboardLayer notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(KeyboardLayer Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: KeyboardLayerProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<KeyboardLayer, KbLayerEnum>
+      createElement() {
+    return _KeyboardLayerProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -143,15 +185,20 @@ class KeyboardLayerProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin KeyboardLayerRef on AutoDisposeNotifierProviderRef<KbLayerEnum> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _KeyboardLayerProviderElement
+    extends AutoDisposeNotifierProviderElement<KeyboardLayer, KbLayerEnum>
+    with KeyboardLayerRef {
+  _KeyboardLayerProviderElement(super.provider);
 
   @override
-  KbLayerEnum runNotifierBuild(
-    covariant KeyboardLayer notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as KeyboardLayerProvider).viewId;
 }
 
 String _$keyboardCaseHash() => r'393a7d3c147186e29e841bd2a90b460724e7da0b';
@@ -211,8 +258,8 @@ class KeyboardCaseProvider
     extends AutoDisposeNotifierProviderImpl<KeyboardCase, Case> {
   /// See also [KeyboardCase].
   KeyboardCaseProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => KeyboardCase()..viewId = viewId,
           from: keyboardCaseProvider,
           name: r'keyboardCaseProvider',
@@ -223,9 +270,50 @@ class KeyboardCaseProvider
           dependencies: KeyboardCaseFamily._dependencies,
           allTransitiveDependencies:
               KeyboardCaseFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  KeyboardCaseProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  Case runNotifierBuild(
+    covariant KeyboardCase notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(KeyboardCase Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: KeyboardCaseProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<KeyboardCase, Case> createElement() {
+    return _KeyboardCaseProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -239,15 +327,20 @@ class KeyboardCaseProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin KeyboardCaseRef on AutoDisposeNotifierProviderRef<Case> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _KeyboardCaseProviderElement
+    extends AutoDisposeNotifierProviderElement<KeyboardCase, Case>
+    with KeyboardCaseRef {
+  _KeyboardCaseProviderElement(super.provider);
 
   @override
-  Case runNotifierBuild(
-    covariant KeyboardCase notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as KeyboardCaseProvider).viewId;
 }
 
 String _$keyboardKeyWidthHash() => r'dff0fb730a1a44c86d543f492625d64dfe2a51ea';
@@ -307,8 +400,8 @@ class KeyboardKeyWidthProvider
     extends NotifierProviderImpl<KeyboardKeyWidth, double> {
   /// See also [KeyboardKeyWidth].
   KeyboardKeyWidthProvider(
-    this.viewId,
-  ) : super.internal(
+    int viewId,
+  ) : this._internal(
           () => KeyboardKeyWidth()..viewId = viewId,
           from: keyboardKeyWidthProvider,
           name: r'keyboardKeyWidthProvider',
@@ -319,9 +412,50 @@ class KeyboardKeyWidthProvider
           dependencies: KeyboardKeyWidthFamily._dependencies,
           allTransitiveDependencies:
               KeyboardKeyWidthFamily._allTransitiveDependencies,
+          viewId: viewId,
         );
 
+  KeyboardKeyWidthProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.viewId,
+  }) : super.internal();
+
   final int viewId;
+
+  @override
+  double runNotifierBuild(
+    covariant KeyboardKeyWidth notifier,
+  ) {
+    return notifier.build(
+      viewId,
+    );
+  }
+
+  @override
+  Override overrideWith(KeyboardKeyWidth Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: KeyboardKeyWidthProvider._internal(
+        () => create()..viewId = viewId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        viewId: viewId,
+      ),
+    );
+  }
+
+  @override
+  NotifierProviderElement<KeyboardKeyWidth, double> createElement() {
+    return _KeyboardKeyWidthProviderElement(this);
+  }
 
   @override
   bool operator ==(Object other) {
@@ -335,14 +469,20 @@ class KeyboardKeyWidthProvider
 
     return _SystemHash.finish(hash);
   }
+}
+
+mixin KeyboardKeyWidthRef on NotifierProviderRef<double> {
+  /// The parameter `viewId` of this provider.
+  int get viewId;
+}
+
+class _KeyboardKeyWidthProviderElement
+    extends NotifierProviderElement<KeyboardKeyWidth, double>
+    with KeyboardKeyWidthRef {
+  _KeyboardKeyWidthProviderElement(super.provider);
 
   @override
-  double runNotifierBuild(
-    covariant KeyboardKeyWidth notifier,
-  ) {
-    return notifier.build(
-      viewId,
-    );
-  }
+  int get viewId => (origin as KeyboardKeyWidthProvider).viewId;
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/util/mouse_button_tracker.g.dart
+++ b/veshell_flutter/lib/generated/util/mouse_button_tracker.g.dart
@@ -22,4 +22,5 @@ final mouseButtonTrackerProvider = Provider<MouseButtonTracker>.internal(
 );
 
 typedef MouseButtonTrackerRef = ProviderRef<MouseButtonTracker>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/util/pointer_focus_manager.g.dart
+++ b/veshell_flutter/lib/generated/util/pointer_focus_manager.g.dart
@@ -22,4 +22,5 @@ final pointerFocusManagerProvider = Provider<PointerFocusManager>.internal(
 );
 
 typedef PointerFocusManagerRef = ProviderRef<PointerFocusManager>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/util/state/display_brightness_state.freezed.dart
+++ b/veshell_flutter/lib/generated/util/state/display_brightness_state.freezed.dart
@@ -87,11 +87,12 @@ class _$DisplayBrightnessStateCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_DisplayBrightnessStateCopyWith<$Res>
+abstract class _$$DisplayBrightnessStateImplCopyWith<$Res>
     implements $DisplayBrightnessStateCopyWith<$Res> {
-  factory _$$_DisplayBrightnessStateCopyWith(_$_DisplayBrightnessState value,
-          $Res Function(_$_DisplayBrightnessState) then) =
-      __$$_DisplayBrightnessStateCopyWithImpl<$Res>;
+  factory _$$DisplayBrightnessStateImplCopyWith(
+          _$DisplayBrightnessStateImpl value,
+          $Res Function(_$DisplayBrightnessStateImpl) then) =
+      __$$DisplayBrightnessStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -103,12 +104,13 @@ abstract class _$$_DisplayBrightnessStateCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_DisplayBrightnessStateCopyWithImpl<$Res>
+class __$$DisplayBrightnessStateImplCopyWithImpl<$Res>
     extends _$DisplayBrightnessStateCopyWithImpl<$Res,
-        _$_DisplayBrightnessState>
-    implements _$$_DisplayBrightnessStateCopyWith<$Res> {
-  __$$_DisplayBrightnessStateCopyWithImpl(_$_DisplayBrightnessState _value,
-      $Res Function(_$_DisplayBrightnessState) _then)
+        _$DisplayBrightnessStateImpl>
+    implements _$$DisplayBrightnessStateImplCopyWith<$Res> {
+  __$$DisplayBrightnessStateImplCopyWithImpl(
+      _$DisplayBrightnessStateImpl _value,
+      $Res Function(_$DisplayBrightnessStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -120,7 +122,7 @@ class __$$_DisplayBrightnessStateCopyWithImpl<$Res>
     Object? brightness = null,
     Object? savedBrightness = null,
   }) {
-    return _then(_$_DisplayBrightnessState(
+    return _then(_$DisplayBrightnessStateImpl(
       available: null == available
           ? _value.available
           : available // ignore: cast_nullable_to_non_nullable
@@ -147,8 +149,8 @@ class __$$_DisplayBrightnessStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_DisplayBrightnessState implements _DisplayBrightnessState {
-  const _$_DisplayBrightnessState(
+class _$DisplayBrightnessStateImpl implements _DisplayBrightnessState {
+  const _$DisplayBrightnessStateImpl(
       {required this.available,
       required this.brightnessFile,
       required this.maxBrightness,
@@ -175,7 +177,7 @@ class _$_DisplayBrightnessState implements _DisplayBrightnessState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DisplayBrightnessState &&
+            other is _$DisplayBrightnessStateImpl &&
             (identical(other.available, available) ||
                 other.available == available) &&
             (identical(other.brightnessFile, brightnessFile) ||
@@ -195,9 +197,9 @@ class _$_DisplayBrightnessState implements _DisplayBrightnessState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DisplayBrightnessStateCopyWith<_$_DisplayBrightnessState> get copyWith =>
-      __$$_DisplayBrightnessStateCopyWithImpl<_$_DisplayBrightnessState>(
-          this, _$identity);
+  _$$DisplayBrightnessStateImplCopyWith<_$DisplayBrightnessStateImpl>
+      get copyWith => __$$DisplayBrightnessStateImplCopyWithImpl<
+          _$DisplayBrightnessStateImpl>(this, _$identity);
 }
 
 abstract class _DisplayBrightnessState implements DisplayBrightnessState {
@@ -206,7 +208,7 @@ abstract class _DisplayBrightnessState implements DisplayBrightnessState {
       required final File brightnessFile,
       required final int maxBrightness,
       required final double brightness,
-      required final double savedBrightness}) = _$_DisplayBrightnessState;
+      required final double savedBrightness}) = _$DisplayBrightnessStateImpl;
 
   @override
   bool get available;
@@ -220,6 +222,6 @@ abstract class _DisplayBrightnessState implements DisplayBrightnessState {
   double get savedBrightness;
   @override
   @JsonKey(ignore: true)
-  _$$_DisplayBrightnessStateCopyWith<_$_DisplayBrightnessState> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DisplayBrightnessStateImplCopyWith<_$DisplayBrightnessStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/util/state/key_tracker.freezed.dart
+++ b/veshell_flutter/lib/generated/util/state/key_tracker.freezed.dart
@@ -80,10 +80,11 @@ class _$KeyStateCopyWithImpl<$Res, $Val extends KeyState>
 }
 
 /// @nodoc
-abstract class _$$_KeyStateCopyWith<$Res> implements $KeyStateCopyWith<$Res> {
-  factory _$$_KeyStateCopyWith(
-          _$_KeyState value, $Res Function(_$_KeyState) then) =
-      __$$_KeyStateCopyWithImpl<$Res>;
+abstract class _$$KeyStateImplCopyWith<$Res>
+    implements $KeyStateCopyWith<$Res> {
+  factory _$$KeyStateImplCopyWith(
+          _$KeyStateImpl value, $Res Function(_$KeyStateImpl) then) =
+      __$$KeyStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -96,11 +97,11 @@ abstract class _$$_KeyStateCopyWith<$Res> implements $KeyStateCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_KeyStateCopyWithImpl<$Res>
-    extends _$KeyStateCopyWithImpl<$Res, _$_KeyState>
-    implements _$$_KeyStateCopyWith<$Res> {
-  __$$_KeyStateCopyWithImpl(
-      _$_KeyState _value, $Res Function(_$_KeyState) _then)
+class __$$KeyStateImplCopyWithImpl<$Res>
+    extends _$KeyStateCopyWithImpl<$Res, _$KeyStateImpl>
+    implements _$$KeyStateImplCopyWith<$Res> {
+  __$$KeyStateImplCopyWithImpl(
+      _$KeyStateImpl _value, $Res Function(_$KeyStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -113,7 +114,7 @@ class __$$_KeyStateCopyWithImpl<$Res>
     Object? up = null,
     Object? longPressTimer = freezed,
   }) {
-    return _then(_$_KeyState(
+    return _then(_$KeyStateImpl(
       isDown: null == isDown
           ? _value.isDown
           : isDown // ignore: cast_nullable_to_non_nullable
@@ -132,8 +133,8 @@ class __$$_KeyStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_KeyState implements _KeyState {
-  const _$_KeyState(
+class _$KeyStateImpl implements _KeyState {
+  const _$KeyStateImpl(
       {required this.isDown,
       required this.down,
       required this.longPress,
@@ -163,7 +164,7 @@ class _$_KeyState implements _KeyState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_KeyState &&
+            other is _$KeyStateImpl &&
             (identical(other.isDown, isDown) || other.isDown == isDown) &&
             const DeepCollectionEquality().equals(other.down, down) &&
             const DeepCollectionEquality().equals(other.longPress, longPress) &&
@@ -187,8 +188,8 @@ class _$_KeyState implements _KeyState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_KeyStateCopyWith<_$_KeyState> get copyWith =>
-      __$$_KeyStateCopyWithImpl<_$_KeyState>(this, _$identity);
+  _$$KeyStateImplCopyWith<_$KeyStateImpl> get copyWith =>
+      __$$KeyStateImplCopyWithImpl<_$KeyStateImpl>(this, _$identity);
 }
 
 abstract class _KeyState implements KeyState {
@@ -198,7 +199,7 @@ abstract class _KeyState implements KeyState {
       required final Object longPress,
       required final Object shortPress,
       required final Object up,
-      required final Timer? longPressTimer}) = _$_KeyState;
+      required final Timer? longPressTimer}) = _$KeyStateImpl;
 
   @override
   bool get isDown;
@@ -214,6 +215,6 @@ abstract class _KeyState implements KeyState {
   Timer? get longPressTimer;
   @override
   @JsonKey(ignore: true)
-  _$$_KeyStateCopyWith<_$_KeyState> get copyWith =>
+  _$$KeyStateImplCopyWith<_$KeyStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/util/state/lock_screen_state.freezed.dart
+++ b/veshell_flutter/lib/generated/util/state/lock_screen_state.freezed.dart
@@ -63,22 +63,22 @@ class _$LockScreenStateCopyWithImpl<$Res, $Val extends LockScreenState>
 }
 
 /// @nodoc
-abstract class _$$_LockScreenStateCopyWith<$Res>
+abstract class _$$LockScreenStateImplCopyWith<$Res>
     implements $LockScreenStateCopyWith<$Res> {
-  factory _$$_LockScreenStateCopyWith(
-          _$_LockScreenState value, $Res Function(_$_LockScreenState) then) =
-      __$$_LockScreenStateCopyWithImpl<$Res>;
+  factory _$$LockScreenStateImplCopyWith(_$LockScreenStateImpl value,
+          $Res Function(_$LockScreenStateImpl) then) =
+      __$$LockScreenStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool locked, Object lock, Object unlock});
 }
 
 /// @nodoc
-class __$$_LockScreenStateCopyWithImpl<$Res>
-    extends _$LockScreenStateCopyWithImpl<$Res, _$_LockScreenState>
-    implements _$$_LockScreenStateCopyWith<$Res> {
-  __$$_LockScreenStateCopyWithImpl(
-      _$_LockScreenState _value, $Res Function(_$_LockScreenState) _then)
+class __$$LockScreenStateImplCopyWithImpl<$Res>
+    extends _$LockScreenStateCopyWithImpl<$Res, _$LockScreenStateImpl>
+    implements _$$LockScreenStateImplCopyWith<$Res> {
+  __$$LockScreenStateImplCopyWithImpl(
+      _$LockScreenStateImpl _value, $Res Function(_$LockScreenStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -88,7 +88,7 @@ class __$$_LockScreenStateCopyWithImpl<$Res>
     Object? lock = null,
     Object? unlock = null,
   }) {
-    return _then(_$_LockScreenState(
+    return _then(_$LockScreenStateImpl(
       locked: null == locked
           ? _value.locked
           : locked // ignore: cast_nullable_to_non_nullable
@@ -101,8 +101,8 @@ class __$$_LockScreenStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_LockScreenState implements _LockScreenState {
-  const _$_LockScreenState(
+class _$LockScreenStateImpl implements _LockScreenState {
+  const _$LockScreenStateImpl(
       {required this.locked, required this.lock, required this.unlock});
 
   @override
@@ -121,7 +121,7 @@ class _$_LockScreenState implements _LockScreenState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LockScreenState &&
+            other is _$LockScreenStateImpl &&
             (identical(other.locked, locked) || other.locked == locked) &&
             const DeepCollectionEquality().equals(other.lock, lock) &&
             const DeepCollectionEquality().equals(other.unlock, unlock));
@@ -137,15 +137,16 @@ class _$_LockScreenState implements _LockScreenState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LockScreenStateCopyWith<_$_LockScreenState> get copyWith =>
-      __$$_LockScreenStateCopyWithImpl<_$_LockScreenState>(this, _$identity);
+  _$$LockScreenStateImplCopyWith<_$LockScreenStateImpl> get copyWith =>
+      __$$LockScreenStateImplCopyWithImpl<_$LockScreenStateImpl>(
+          this, _$identity);
 }
 
 abstract class _LockScreenState implements LockScreenState {
   const factory _LockScreenState(
       {required final bool locked,
       required final Object lock,
-      required final Object unlock}) = _$_LockScreenState;
+      required final Object unlock}) = _$LockScreenStateImpl;
 
   @override
   bool get locked;
@@ -155,6 +156,6 @@ abstract class _LockScreenState implements LockScreenState {
   Object get unlock;
   @override
   @JsonKey(ignore: true)
-  _$$_LockScreenStateCopyWith<_$_LockScreenState> get copyWith =>
+  _$$LockScreenStateImplCopyWith<_$LockScreenStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/util/state/root_overlay.g.dart
+++ b/veshell_flutter/lib/generated/util/state/root_overlay.g.dart
@@ -21,4 +21,5 @@ final rootOverlayKeyProvider = Provider<GlobalKey<OverlayState>>.internal(
 );
 
 typedef RootOverlayKeyRef = ProviderRef<GlobalKey<OverlayState>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/util/state/screen_state.freezed.dart
+++ b/veshell_flutter/lib/generated/util/state/screen_state.freezed.dart
@@ -91,22 +91,22 @@ class _$ScreenStateCopyWithImpl<$Res, $Val extends ScreenState>
 }
 
 /// @nodoc
-abstract class _$$_ScreenStateCopyWith<$Res>
+abstract class _$$ScreenStateImplCopyWith<$Res>
     implements $ScreenStateCopyWith<$Res> {
-  factory _$$_ScreenStateCopyWith(
-          _$_ScreenState value, $Res Function(_$_ScreenState) then) =
-      __$$_ScreenStateCopyWithImpl<$Res>;
+  factory _$$ScreenStateImplCopyWith(
+          _$ScreenStateImpl value, $Res Function(_$ScreenStateImpl) then) =
+      __$$ScreenStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool on, bool pending, int rotation, Size size, Size rotatedSize});
 }
 
 /// @nodoc
-class __$$_ScreenStateCopyWithImpl<$Res>
-    extends _$ScreenStateCopyWithImpl<$Res, _$_ScreenState>
-    implements _$$_ScreenStateCopyWith<$Res> {
-  __$$_ScreenStateCopyWithImpl(
-      _$_ScreenState _value, $Res Function(_$_ScreenState) _then)
+class __$$ScreenStateImplCopyWithImpl<$Res>
+    extends _$ScreenStateCopyWithImpl<$Res, _$ScreenStateImpl>
+    implements _$$ScreenStateImplCopyWith<$Res> {
+  __$$ScreenStateImplCopyWithImpl(
+      _$ScreenStateImpl _value, $Res Function(_$ScreenStateImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -118,7 +118,7 @@ class __$$_ScreenStateCopyWithImpl<$Res>
     Object? size = null,
     Object? rotatedSize = null,
   }) {
-    return _then(_$_ScreenState(
+    return _then(_$ScreenStateImpl(
       on: null == on
           ? _value.on
           : on // ignore: cast_nullable_to_non_nullable
@@ -145,8 +145,8 @@ class __$$_ScreenStateCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ScreenState implements _ScreenState {
-  const _$_ScreenState(
+class _$ScreenStateImpl implements _ScreenState {
+  const _$ScreenStateImpl(
       {required this.on,
       required this.pending,
       required this.rotation,
@@ -183,7 +183,7 @@ class _$_ScreenState implements _ScreenState {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ScreenState &&
+            other is _$ScreenStateImpl &&
             (identical(other.on, on) || other.on == on) &&
             (identical(other.pending, pending) || other.pending == pending) &&
             (identical(other.rotation, rotation) ||
@@ -200,8 +200,8 @@ class _$_ScreenState implements _ScreenState {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ScreenStateCopyWith<_$_ScreenState> get copyWith =>
-      __$$_ScreenStateCopyWithImpl<_$_ScreenState>(this, _$identity);
+  _$$ScreenStateImplCopyWith<_$ScreenStateImpl> get copyWith =>
+      __$$ScreenStateImplCopyWithImpl<_$ScreenStateImpl>(this, _$identity);
 }
 
 abstract class _ScreenState implements ScreenState {
@@ -210,7 +210,7 @@ abstract class _ScreenState implements ScreenState {
       required final bool pending,
       required final int rotation,
       required final Size size,
-      required final Size rotatedSize}) = _$_ScreenState;
+      required final Size rotatedSize}) = _$ScreenStateImpl;
 
   @override
   bool get on;
@@ -234,6 +234,6 @@ abstract class _ScreenState implements ScreenState {
   Size get rotatedSize;
   @override
   @JsonKey(ignore: true)
-  _$$_ScreenStateCopyWith<_$_ScreenState> get copyWith =>
+  _$$ScreenStateImplCopyWith<_$ScreenStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/veshell_flutter/lib/generated/util/state/screen_state.g.dart
+++ b/veshell_flutter/lib/generated/util/state/screen_state.g.dart
@@ -23,4 +23,5 @@ final screenStateNotifierProvider =
 );
 
 typedef _$ScreenStateNotifier = Notifier<ScreenState>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/generated/util/state/ui_mode_state.g.dart
+++ b/veshell_flutter/lib/generated/util/state/ui_mode_state.g.dart
@@ -20,4 +20,5 @@ final uiModeStateProvider = NotifierProvider<UiModeState, UiMode>.internal(
 );
 
 typedef _$UiModeState = Notifier<UiMode>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/veshell_flutter/lib/ui/common/state/subsurface_state.dart
+++ b/veshell_flutter/lib/ui/common/state/subsurface_state.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:zenith/ui/common/state/surface_ids.dart';
+import 'package:zenith/ui/common/state/surface_state.dart';
+import 'package:zenith/ui/common/state/xdg_surface_state.dart';
 import 'package:zenith/ui/common/subsurface.dart';
 
 part '../../../generated/ui/common/state/subsurface_state.freezed.dart';
+
 part '../../../generated/ui/common/state/subsurface_state.g.dart';
 
 @Riverpod(keepAlive: true)
@@ -12,38 +17,89 @@ Subsurface subsurfaceWidget(SubsurfaceWidgetRef ref, int viewId) {
     key: ref.watch(subsurfaceStatesProvider(viewId).select((state) => state.widgetKey)),
     viewId: viewId,
   );
-
 }
 
 @freezed
 class SubsurfaceState with _$SubsurfaceState {
   const factory SubsurfaceState({
-    required Offset position, // relative to the parent
     required bool mapped,
+    required int parent,
+    required Offset position, // relative to the parent
     required Key widgetKey,
   }) = _SubsurfaceState;
 }
 
 @Riverpod(keepAlive: true)
 class SubsurfaceStates extends _$SubsurfaceStates {
+  ProviderSubscription<SurfaceRole>? parentRoleSub;
+  ProviderSubscription<bool>? parentMappedSub;
+
   @override
   SubsurfaceState build(int viewId) {
+    ref.listen(surfaceStatesProvider(viewId).select((state) => state.textureId), (_, __) => _checkIfMapped());
+    ref.listen(surfaceIdsProvider, (_, __) => _checkIfMapped());
+
     return SubsurfaceState(
-      position: Offset.zero,
       mapped: false,
+      parent: 0,
+      position: Offset.zero,
       widgetKey: GlobalKey(),
     );
+  }
+
+  void _checkIfMapped() {
+    bool parentMapped = false;
+    if (ref.read(surfaceIdsProvider).contains(state.parent)) {
+      var role = ref.read(surfaceStatesProvider(state.parent)).role;
+      switch (role) {
+        case SurfaceRole.xdgSurface:
+          parentMapped = ref.read(xdgSurfaceStatesProvider(state.parent)).mapped;
+        case SurfaceRole.subsurface:
+          parentMapped = ref.read(subsurfaceStatesProvider(state.parent)).mapped;
+        case SurfaceRole.none:
+      }
+    }
+
+    bool mapped = parentMapped && ref.read(surfaceStatesProvider(viewId)).textureId.value != -1;
+
+    state = state.copyWith(
+      mapped: mapped,
+    );
+  }
+
+  void set_parent(int parent) {
+    state = state.copyWith(
+      parent: parent,
+    );
+    _checkIfMapped();
+
+    if (!ref.read(surfaceIdsProvider).contains(parent)) {
+      parentRoleSub?.close();
+      parentMappedSub?.close();
+      return;
+    }
+
+    parentRoleSub?.close();
+    parentRoleSub =
+        ref.listen(surfaceStatesProvider(parent).select((value) => value.role), (_, __) => _checkIfMapped());
+
+    parentMappedSub?.close();
+    // print("$viewId, parent: $parent");
+    var role = ref.read(surfaceStatesProvider(parent)).role;
+    switch (role) {
+      case SurfaceRole.xdgSurface:
+        parentMappedSub =
+            ref.listen(xdgSurfaceStatesProvider(parent).select((state) => state.mapped), (_, __) => _checkIfMapped());
+      case SurfaceRole.subsurface:
+        parentMappedSub =
+            ref.listen(subsurfaceStatesProvider(parent).select((state) => state.mapped), (_, __) => _checkIfMapped());
+      case SurfaceRole.none:
+    }
   }
 
   void commit({required Offset position}) {
     state = state.copyWith(
       position: position,
-    );
-  }
-
-  void map(bool value) {
-    state = state.copyWith(
-      mapped: value,
     );
   }
 

--- a/veshell_flutter/lib/ui/common/state/surface_ids.dart
+++ b/veshell_flutter/lib/ui/common/state/surface_ids.dart
@@ -1,0 +1,22 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part '../../../generated/ui/common/state/surface_ids.g.dart';
+
+@Riverpod(keepAlive: true)
+class SurfaceIds extends _$SurfaceIds {
+  @override
+  ISet<int> build() {
+    return ISet();
+  }
+
+  // Make it public. Was protected in the superclass.
+  @override
+  set state(ISet<int> value) {
+    super.state = value;
+  }
+
+  void update(ISet<int> Function(ISet<int>) callback) {
+    super.state = callback(state);
+  }
+}

--- a/veshell_flutter/lib/ui/common/state/surface_state.dart
+++ b/veshell_flutter/lib/ui/common/state/surface_state.dart
@@ -80,8 +80,6 @@ class SurfaceStates extends _$SurfaceStates {
       currentTexture = textureId;
     }
 
-    print("new texture ${textureId.value} for $viewId");
-
     state = state.copyWith(
       role: role,
       textureId: currentTexture,
@@ -92,6 +90,12 @@ class SurfaceStates extends _$SurfaceStates {
       subsurfacesBelow: subsurfacesBelow,
       subsurfacesAbove: subsurfacesAbove,
       inputRegion: inputRegion,
+    );
+  }
+
+  void unmap() {
+    state = state.copyWith(
+      role: SurfaceRole.none,
     );
   }
 

--- a/veshell_flutter/lib/ui/desktop/window.dart
+++ b/veshell_flutter/lib/ui/desktop/window.dart
@@ -110,40 +110,21 @@ class _WindowState extends ConsumerState<Window> with SingleTickerProviderStateM
             break;
         }
 
-        return TweenAnimationBuilder(
-          duration: duration,
-          tween: Tween(begin: offset, end: offset),
-          curve: Curves.easeInOutCubic,
-          builder: (context, offset, child) {
-            return TweenAnimationBuilder(
-              duration: duration,
-              tween: Tween(begin: position, end: position),
-              curve: Curves.easeInOutCubic,
-              builder: (context, position, child) {
-                return Positioned(
-                  left: position.dx - offset.dx,
-                  top: position.dy - offset.dy,
-                  child: child!,
-                );
-              },
-              child: child,
-            );
-          },
-          child: child,
+        return Positioned(
+          left: position.dx - offset.dx,
+          top: position.dy - offset.dy,
+          child: child!,
         );
       },
       child: _OpenCloseAnimations(
         viewId: widget.viewId,
-        child: _TilingAnimations(
-          viewId: widget.viewId,
-          child: RepaintBoundary(
-            key: ref.watch(windowStateProvider(widget.viewId).select((value) => value.repaintBoundaryKey)),
-            child: WithDecorations(
+        child: RepaintBoundary(
+          key: ref.watch(windowStateProvider(widget.viewId).select((value) => value.repaintBoundaryKey)),
+          child: WithDecorations(
+            viewId: widget.viewId,
+            child: InteractiveMoveAndResizeListener(
               viewId: widget.viewId,
-              child: InteractiveMoveAndResizeListener(
-                viewId: widget.viewId,
-                child: ref.watch(xdgToplevelSurfaceWidgetProvider(widget.viewId)),
-              ),
+              child: ref.watch(xdgToplevelSurfaceWidgetProvider(widget.viewId)),
             ),
           ),
         ),
@@ -212,7 +193,6 @@ class _OpenCloseAnimationsState extends ConsumerState<_OpenCloseAnimations> {
           onEnd: () {
             if (!forward) {
               ref.read(windowStackProvider.notifier).remove(widget.viewId);
-              print("remove");
             }
           },
         ),


### PR DESCRIPTION
- Updated Smithay which fixes this bug: https://github.com/Smithay/smithay/pull/1201
- Synchronize OpenGL textures imported from shm buffers using glFinish before registering them to the Flutter engine
- Track popup and subsurface creation, and serialize their state for Flutter
- Notify Flutter when a surface of any kind is destroyed
- Determine when a surface gets mapped/unmapped from existing state in Flutter using the reactive nature of Riverpod, instead of sending these events through platform channels.

Note that only the X11 backend works well at the moment. Most Wayland clients work pretty well, including Chrome and Firefox, but some bugs are still present with subsurfaces.