### PR TITLE
Fix DRM backend crashing at startup and some code deduplication

### DIFF
--- a/src/flutter_engine.rs
+++ b/src/flutter_engine.rs
@@ -51,7 +51,7 @@ use crate::{Backend, CalloopData, flutter_engine::{
 }, ServerState};
 use crate::flutter_engine::callbacks::{gl_external_texture_frame_callback, platform_message_callback, populate_existing_damage, post_task_callback, runs_task_on_current_thread_callback, vsync_callback};
 use crate::flutter_engine::embedder::{FlutterCustomTaskRunners, FlutterEngineMarkExternalTextureFrameAvailable, FlutterEngineRegisterExternalTexture, FlutterEngineRunTask, FlutterEngineSendPointerEvent, FlutterPointerEvent, FlutterTaskRunnerDescription};
-use crate::flutter_engine::platform_channel_callbacks::platform_message_handler;
+use crate::flutter_engine::platform_channel_callbacks::platform_channel_method_handler;
 use crate::flutter_engine::platform_channels::binary_messenger::BinaryMessenger;
 use crate::flutter_engine::platform_channels::binary_messenger_impl::BinaryMessengerImpl;
 use crate::flutter_engine::platform_channels::encodable_value::EncodableValue;
@@ -284,7 +284,7 @@ impl<BackendData: Backend + 'static> FlutterEngine<BackendData> {
 
         server_state.loop_handle.insert_source(
             rx_platform_message,
-            platform_message_handler,
+            platform_channel_method_handler,
         ).unwrap();
 
         Ok((this, embedder_channels))

--- a/src/flutter_engine/platform_channel_callbacks.rs
+++ b/src/flutter_engine/platform_channel_callbacks.rs
@@ -13,7 +13,7 @@ use crate::flutter_engine::platform_channels::method_call::MethodCall;
 use crate::flutter_engine::platform_channels::method_result::MethodResult;
 use crate::mouse_button_tracker::FLUTTER_TO_LINUX_MOUSE_BUTTONS;
 
-pub fn platform_message_handler<BackendData: Backend + 'static>(
+pub fn platform_channel_method_handler<BackendData: Backend + 'static>(
     event: Event<(MethodCall, Box<dyn MethodResult>)>,
     _: &mut (),
     data: &mut CalloopData<BackendData>,

--- a/src/flutter_engine/platform_channel_callbacks.rs
+++ b/src/flutter_engine/platform_channel_callbacks.rs
@@ -1,0 +1,180 @@
+use std::time::Duration;
+
+use smithay::backend::input::ButtonState;
+use smithay::input::pointer::{ButtonEvent, MotionEvent};
+use smithay::reexports::calloop::channel::Event;
+use smithay::reexports::calloop::channel::Event::Msg;
+use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
+use smithay::utils::SERIAL_COUNTER;
+
+use crate::{Backend, CalloopData};
+use crate::flutter_engine::platform_channels::encodable_value::EncodableValue;
+use crate::flutter_engine::platform_channels::method_call::MethodCall;
+use crate::flutter_engine::platform_channels::method_result::MethodResult;
+use crate::mouse_button_tracker::FLUTTER_TO_LINUX_MOUSE_BUTTONS;
+
+pub fn platform_message_handler<BackendData: Backend + 'static>(
+    event: Event<(MethodCall, Box<dyn MethodResult>)>,
+    _: &mut (),
+    data: &mut CalloopData<BackendData>,
+) {
+    if let Msg((method_call, mut result)) = event {
+        match method_call.method() {
+            "pointer_hover" => pointer_hover(method_call, result, data),
+            "pointer_exit" => pointer_exit(method_call, result, data),
+            "mouse_button_event" => mouse_button_event(method_call, result, data),
+            "activate_window" => activate_window(method_call, result, data),
+            _ => result.error(
+                "method_not_found".to_string(),
+                format!("Method {} not found", method_call.method()),
+                None,
+            ),
+        }
+    }
+}
+
+macro_rules! extract {
+    ($e:expr, $p:path) => {
+        match $e {
+            $p(value) => value,
+            _ => panic!("Failed to extract value"),
+        }
+    };
+}
+
+fn get<'a>(map: &'a EncodableValue, key: &str) -> &'a EncodableValue {
+    let map = extract!(map, EncodableValue::Map);
+    // TODO: Lookup should be constant time, not linear.
+    for (k, v) in map {
+        if let EncodableValue::String(k) = k {
+            if k == key {
+                return v;
+            }
+        }
+    }
+    panic!("Key {} not found in map", key);
+}
+
+pub fn pointer_hover<BackendData: Backend + 'static>(
+    method_call: MethodCall,
+    mut result: Box<dyn MethodResult>,
+    data: &mut CalloopData<BackendData>,
+) {
+    let args = method_call.arguments().unwrap();
+    let view_id = get(args, "view_id").long_value().unwrap();
+    let x = *extract!(get(args, "x"), EncodableValue::Double);
+    let y = *extract!(get(args, "y"), EncodableValue::Double);
+
+    data.state.view_id_under_cursor = Some(view_id as u64);
+
+    if let Some(surface) = data.state.surfaces.get(&(view_id as u64)).cloned() {
+        let now = Duration::from(data.state.clock.now()).as_millis() as u32;
+        let pointer = data.state.pointer.clone();
+
+        pointer.motion(
+            &mut data.state,
+            Some((surface.clone(), (0, 0).into())),
+            &MotionEvent {
+                location: (x, y).into(),
+                serial: SERIAL_COUNTER.next_serial(),
+                time: now,
+            },
+        );
+        pointer.frame(&mut data.state);
+        result.success(None);
+    } else {
+        result.error(
+            "surface_doesnt_exist".to_string(),
+            format!("Surface {view_id} doesn't exist"),
+            None,
+        );
+    }
+}
+
+pub fn pointer_exit<BackendData: Backend + 'static>(
+    method_call: MethodCall,
+    mut result: Box<dyn MethodResult>,
+    data: &mut CalloopData<BackendData>,
+) {
+    let now = Duration::from(data.state.clock.now()).as_millis() as u32;
+    let pointer = data.state.pointer.clone();
+
+    data.state.view_id_under_cursor = None;
+
+    pointer.motion(
+        &mut data.state,
+        None,
+        &MotionEvent {
+            location: (0.0, 0.0).into(),
+            serial: SERIAL_COUNTER.next_serial(),
+            time: now,
+        },
+    );
+    result.success(None);
+}
+
+pub fn mouse_button_event<BackendData: Backend + 'static>(
+    method_call: MethodCall,
+    mut result: Box<dyn MethodResult>,
+    data: &mut CalloopData<BackendData>,
+) {
+    let now = Duration::from(data.state.clock.now()).as_millis() as u32;
+    let pointer = data.state.pointer.clone();
+
+    let args = method_call.arguments().unwrap();
+    let button = get(args, "button").long_value().unwrap();
+    let is_pressed = *extract!(get(args, "is_pressed"), EncodableValue::Bool);
+
+    pointer.button(
+        &mut data.state,
+        &ButtonEvent {
+            serial: SERIAL_COUNTER.next_serial(),
+            time: now,
+            button: *FLUTTER_TO_LINUX_MOUSE_BUTTONS.get(&(button as u32)).unwrap() as u32,
+            state: if is_pressed { ButtonState::Pressed } else { ButtonState::Released },
+        },
+    );
+    pointer.frame(&mut data.state);
+    result.success(None);
+}
+
+pub fn activate_window<BackendData: Backend + 'static>(
+    method_call: MethodCall,
+    mut result: Box<dyn MethodResult>,
+    data: &mut CalloopData<BackendData>,
+) {
+    let args = method_call.arguments().unwrap();
+    let args = extract!(args, EncodableValue::List);
+    let view_id = args[0].long_value().unwrap();
+    let activate = extract!(args[1], EncodableValue::Bool);
+
+    let pointer = data.state.seat.get_pointer().unwrap();
+    let keyboard = data.state.seat.get_keyboard().unwrap();
+
+    let serial = SERIAL_COUNTER.next_serial();
+
+    if !pointer.is_grabbed() {
+        let toplevel = data.state.xdg_toplevels.get(&(view_id as u64)).cloned();
+        if let Some(toplevel) = toplevel {
+            toplevel.with_pending_state(|state| {
+                if activate {
+                    state.states.set(xdg_toplevel::State::Activated);
+                } else {
+                    state.states.unset(xdg_toplevel::State::Activated);
+                }
+            });
+            keyboard.set_focus(&mut data.state, Some(toplevel.wl_surface().clone()), serial);
+
+            for toplevel in data.state.xdg_toplevels.values() {
+                toplevel.send_pending_configure();
+            }
+            result.success(None);
+        } else {
+            result.error(
+                "surface_doesnt_exist".to_string(),
+                format!("Surface {view_id} doesn't exist"),
+                None,
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,8 @@ pub trait Backend {
     fn seat_name(&self) -> String;
 }
 
-pub struct FlutterState {
-    pub flutter_engine: FlutterEngine,
+pub struct FlutterState<BackendData: Backend + 'static> {
+    pub flutter_engine: FlutterEngine<BackendData>,
     pub mouse_button_tracker: MouseButtonTracker,
 }
 

--- a/src/server_state.rs
+++ b/src/server_state.rs
@@ -50,13 +50,13 @@ pub struct ServerState<BackendData: Backend + 'static> {
     pub data_device_state: DataDeviceState,
     pub pointer: PointerHandle<ServerState<BackendData>>,
     pub backend_data: Box<BackendData>,
-    pub flutter_engine: Option<Box<FlutterEngine>>,
+    pub flutter_engine: Option<Box<FlutterEngine<BackendData>>>,
     pub next_view_id: u64,
     pub next_texture_id: i64,
 
     pub mouse_position: (f64, f64),
     pub view_id_under_cursor: Option<u64>,
-    pub is_next_vblank_scheduled: bool,
+    pub is_next_flutter_frame_scheduled: bool,
 
     pub compositor_state: CompositorState,
     pub xdg_shell_state: XdgShellState,
@@ -89,10 +89,10 @@ impl<BackendData: Backend + 'static> ServerState<BackendData> {
 }
 
 impl<BackendData: Backend + 'static> ServerState<BackendData> {
-    pub fn flutter_engine(&self) -> &FlutterEngine {
+    pub fn flutter_engine(&self) -> &FlutterEngine<BackendData> {
         self.flutter_engine.as_ref().unwrap()
     }
-    pub fn flutter_engine_mut(&mut self) -> &mut FlutterEngine {
+    pub fn flutter_engine_mut(&mut self) -> &mut FlutterEngine<BackendData> {
         self.flutter_engine.as_mut().unwrap()
     }
 }
@@ -172,7 +172,7 @@ impl<BackendData: Backend + 'static> ServerState<BackendData> {
             backend_data: Box::new(backend_data),
             mouse_position: (0.0, 0.0),
             view_id_under_cursor: None,
-            is_next_vblank_scheduled: false,
+            is_next_flutter_frame_scheduled: false,
             compositor_state,
             xdg_shell_state,
             shm_state,

--- a/src/server_state.rs
+++ b/src/server_state.rs
@@ -4,24 +4,21 @@ use std::env::{remove_var, set_var};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 
 use smithay::{delegate_compositor, delegate_data_device, delegate_dmabuf, delegate_output, delegate_seat, delegate_shm, delegate_xdg_shell};
 use smithay::backend::allocator::dmabuf::Dmabuf;
-use smithay::backend::input::ButtonState;
 use smithay::backend::renderer::{ImportAll, Texture};
 use smithay::backend::renderer::gles::ffi::Gles2;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::input::{Seat, SeatHandler, SeatState};
-use smithay::input::pointer::{ButtonEvent, CursorImageStatus, MotionEvent, PointerHandle};
-use smithay::reexports::calloop::{channel, Interest, LoopHandle, Mode, PostAction};
-use smithay::reexports::calloop::channel::Event::Msg;
+use smithay::input::pointer::{CursorImageStatus, PointerHandle};
+use smithay::reexports::calloop::{Interest, LoopHandle, Mode, PostAction};
 use smithay::reexports::calloop::generic::Generic;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::{Client, Display, DisplayHandle, Resource};
 use smithay::reexports::wayland_server::protocol::{wl_buffer, wl_seat};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::utils::{Buffer as BufferCoords, Clock, Monotonic, Rectangle, Serial, SERIAL_COUNTER, Size};
+use smithay::utils::{Buffer as BufferCoords, Clock, Monotonic, Rectangle, Serial, Size};
 use smithay::wayland::buffer::BufferHandler;
 use smithay::wayland::compositor;
 use smithay::wayland::compositor::{BufferAssignment, CompositorClientState, CompositorHandler, CompositorState, SubsurfaceCachedState, SurfaceAttributes, TraversalAction, with_states, with_surface_tree_upward};
@@ -38,12 +35,9 @@ use tracing::{info, warn};
 use crate::{Backend, CalloopData, ClientState};
 use crate::flutter_engine::FlutterEngine;
 use crate::flutter_engine::platform_channels::encodable_value::EncodableValue;
-use crate::flutter_engine::platform_channels::method_call::MethodCall;
 use crate::flutter_engine::platform_channels::method_channel::MethodChannel;
-use crate::flutter_engine::platform_channels::method_result::MethodResult;
 use crate::flutter_engine::platform_channels::standard_method_codec::StandardMethodCodec;
 use crate::flutter_engine::wayland_messages::{SubsurfaceCommitMessage, SurfaceCommitMessage, XdgPopupCommitMessage, XdgSurfaceCommitMessage};
-use crate::mouse_button_tracker::FLUTTER_TO_LINUX_MOUSE_BUTTONS;
 use crate::texture_swap_chain::TextureSwapChain;
 
 pub struct ServerState<BackendData: Backend + 'static> {
@@ -78,8 +72,6 @@ pub struct ServerState<BackendData: Backend + 'static> {
     pub texture_ids_per_view_id: HashMap<u64, Vec<i64>>,
     pub view_id_per_texture_id: HashMap<i64, u64>,
     pub texture_swapchains: HashMap<i64, TextureSwapChain>,
-
-    pub tx_platform_message: Option<channel::Sender<(MethodCall, Box<dyn MethodResult>)>>,
 }
 
 impl<BackendData: Backend + 'static> ServerState<BackendData> {
@@ -172,142 +164,6 @@ impl<BackendData: Backend + 'static> ServerState<BackendData> {
             )
             .expect("Failed to init wayland server source");
 
-        let (tx_platform_message, rx_platform_message) = channel::channel::<(MethodCall, Box<dyn MethodResult>)>();
-
-        macro_rules! extract {
-            ($e:expr, $p:path) => {
-                match $e {
-                    $p(value) => value,
-                    _ => panic!("Failed to extract value"),
-                }
-            };
-        }
-
-        fn get_value<'a>(map: &'a EncodableValue, key: &str) -> &'a EncodableValue {
-            let map = extract!(map, EncodableValue::Map);
-            for (k, v) in map {
-                if let EncodableValue::String(k) = k {
-                    if k == key {
-                        return v;
-                    }
-                }
-            }
-            panic!("Key {} not found in map", key);
-        }
-
-        loop_handle
-            .insert_source(
-                rx_platform_message,
-                |event, (), data| {
-                    if let Msg((method_call, mut result)) = event {
-                        let pointer = data.state.pointer.clone();
-                        let now = Duration::from(data.state.clock.now()).as_millis() as u32;
-
-                        match method_call.method() {
-                            "pointer_hover" => {
-                                let args = method_call.arguments().unwrap();
-                                let view_id = get_value(args, "view_id").long_value().unwrap();
-                                let x = *extract!(get_value(args, "x"), EncodableValue::Double);
-                                let y = *extract!(get_value(args, "y"), EncodableValue::Double);
-
-                                data.state.view_id_under_cursor = Some(view_id as u64);
-
-                                if let Some(surface) = data.state.surfaces.get(&(view_id as u64)).cloned() {
-                                    pointer.motion(
-                                        &mut data.state,
-                                        Some((surface.clone(), (0, 0).into())),
-                                        &MotionEvent {
-                                            location: (x, y).into(),
-                                            serial: SERIAL_COUNTER.next_serial(),
-                                            time: now,
-                                        },
-                                    );
-                                    pointer.frame(&mut data.state);
-                                    result.success(None);
-                                } else {
-                                    result.error(
-                                        "surface_doesnt_exist".to_string(),
-                                        format!("Surface {view_id} doesn't exist"),
-                                        None,
-                                    );
-                                }
-                            }
-                            "pointer_exit" => {
-                                data.state.view_id_under_cursor = None;
-
-                                pointer.motion(
-                                    &mut data.state,
-                                    None,
-                                    &MotionEvent {
-                                        location: (0.0, 0.0).into(),
-                                        serial: SERIAL_COUNTER.next_serial(),
-                                        time: now,
-                                    },
-                                );
-                                result.success(None);
-                            }
-                            "mouse_button_event" => {
-                                let args = method_call.arguments().unwrap();
-                                let button = get_value(args, "button").long_value().unwrap();
-                                let is_pressed = *extract!(get_value(args, "is_pressed"), EncodableValue::Bool);
-
-                                pointer.button(
-                                    &mut data.state,
-                                    &ButtonEvent {
-                                        serial: SERIAL_COUNTER.next_serial(),
-                                        time: now,
-                                        button: *FLUTTER_TO_LINUX_MOUSE_BUTTONS.get(&(button as u32)).unwrap() as u32,
-                                        state: if is_pressed { ButtonState::Pressed } else { ButtonState::Released },
-                                    },
-                                );
-                                pointer.frame(&mut data.state);
-                                result.success(None);
-                            }
-                            "activate_window" => {
-                                let args = method_call.arguments().unwrap();
-                                let args = extract!(args, EncodableValue::List);
-                                let view_id = args[0].long_value().unwrap();
-                                let activate = extract!(args[1], EncodableValue::Bool);
-
-                                let pointer = data.state.seat.get_pointer().unwrap();
-                                let keyboard = data.state.seat.get_keyboard().unwrap();
-
-                                let serial = SERIAL_COUNTER.next_serial();
-
-                                if !pointer.is_grabbed() {
-                                    let toplevel = data.state.xdg_toplevels.get(&(view_id as u64)).cloned();
-                                    if let Some(toplevel) = toplevel {
-                                        toplevel.with_pending_state(|state| {
-                                            if activate {
-                                                state.states.set(xdg_toplevel::State::Activated);
-                                            } else {
-                                                state.states.unset(xdg_toplevel::State::Activated);
-                                            }
-                                        });
-                                        keyboard.set_focus(&mut data.state, Some(toplevel.wl_surface().clone()), serial);
-
-                                        for toplevel in data.state.xdg_toplevels.values() {
-                                            toplevel.send_pending_configure();
-                                        }
-                                        result.success(None);
-                                    } else {
-                                        result.error(
-                                            "surface_doesnt_exist".to_string(),
-                                            format!("Surface {view_id} doesn't exist"),
-                                            None,
-                                        );
-                                    }
-                                }
-                            }
-                            _ => {
-                                result.success(None);
-                            }
-                        }
-                    }
-                },
-            )
-            .expect("Failed to init wayland server source");
-
         Self {
             running: Arc::new(AtomicBool::new(true)),
             display_handle,
@@ -337,7 +193,6 @@ impl<BackendData: Backend + 'static> ServerState<BackendData> {
             texture_ids_per_view_id: HashMap::new(),
             view_id_per_texture_id: HashMap::new(),
             texture_swapchains: HashMap::new(),
-            tx_platform_message: Some(tx_platform_message),
         }
     }
 }
@@ -549,7 +404,7 @@ impl<BackendData: Backend> CompositorHandler for ServerState<BackendData> {
 
                         Some(XdgPopupCommitMessage {
                             parent_id,
-                            geometry: dbg!(popup_data.current.geometry),
+                            geometry: popup_data.current.geometry,
                         })
                     }
                     _ => None,

--- a/src/x11_client.rs
+++ b/src/x11_client.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use std::sync::atomic::Ordering;
 
 use log::{error, warn};
@@ -34,21 +33,15 @@ use smithay::{
     },
     utils::DeviceFd,
 };
-use smithay::backend::renderer::gles::ffi::{Gles2, RGBA8};
+use smithay::backend::renderer::gles::ffi::Gles2;
 use smithay::backend::renderer::gles::GlesRenderer;
-use smithay::backend::renderer::Texture;
 use smithay::output::{Output, PhysicalProperties, Subpixel};
-use smithay::reexports::calloop::channel::Event;
 use smithay::reexports::calloop::channel::Event::Msg;
 use smithay::reexports::wayland_server::protocol::wl_shm;
-use smithay::wayland::dmabuf::{DmabufFeedbackBuilder, DmabufState};
+use smithay::wayland::dmabuf::DmabufState;
 
 use crate::{Backend, CalloopData, flutter_engine::EmbedderChannels, send_frames_surface_tree, ServerState};
 use crate::flutter_engine::FlutterEngine;
-use crate::flutter_engine::platform_channels::binary_messenger::BinaryMessenger;
-use crate::flutter_engine::platform_channels::encodable_value::EncodableValue;
-use crate::flutter_engine::platform_channels::method_channel::MethodChannel;
-use crate::flutter_engine::platform_channels::standard_method_codec::StandardMethodCodec;
 use crate::input_handling::handle_input;
 
 pub fn run_x11_client() {
@@ -142,14 +135,14 @@ pub fn run_x11_client() {
         },
     };
 
-    let dmabuf_formats = egl_context.dmabuf_texture_formats()
-        .iter()
-        .copied()
-        .collect::<Vec<_>>();
-    let dmabuf_default_feedback = DmabufFeedbackBuilder::new(node.dev_id(), dmabuf_formats)
-        .build()
-        .unwrap();
-    let mut dmabuf_state = DmabufState::new();
+    // let dmabuf_formats = egl_context.dmabuf_texture_formats()
+    //     .iter()
+    //     .copied()
+    //     .collect::<Vec<_>>();
+    // let dmabuf_default_feedback = DmabufFeedbackBuilder::new(node.dev_id(), dmabuf_formats)
+    //     .build()
+    //     .unwrap();
+    let dmabuf_state = DmabufState::new();
     // let _dmabuf_global = dmabuf_state.create_global_with_default_feedback::<ServerState<X11Data>>(
     //     &display.handle(),
     //     &dmabuf_default_feedback,
@@ -171,6 +164,11 @@ pub fn run_x11_client() {
         Some(dmabuf_state),
     );
 
+    let gles_renderer = unsafe { GlesRenderer::new(egl_context) }.expect("Failed to initialize GLES");
+
+    state.gles_renderer = Some(gles_renderer);
+    state.gl = Some(Gles2::load_with(|s| unsafe { egl::get_proc_address(s) } as *const _));
+
     let (
         flutter_engine,
         EmbedderChannels {
@@ -179,25 +177,10 @@ pub fn run_x11_client() {
             mut tx_fbo,
             tx_output_height,
             rx_baton,
-            rx_request_external_texture_name,
-            tx_external_texture_name,
         },
-    ) = FlutterEngine::new(&egl_context, &state).unwrap();
+    ) = FlutterEngine::new(&mut state).unwrap();
 
     state.flutter_engine = Some(flutter_engine);
-
-    let codec = Rc::new(StandardMethodCodec::new());
-
-    let tx_platform_message = state.tx_platform_message.take().unwrap();
-    let mut platform_method_channel = MethodChannel::<EncodableValue>::new(
-        state.flutter_engine_mut().binary_messenger.as_mut().unwrap(),
-        "platform".to_string(),
-        codec,
-    );
-    // TODO: Provide a way to specify a channel directly, without registering a callback.
-    platform_method_channel.set_method_call_handler(Some(Box::new(move |method_call, result| {
-        tx_platform_message.send((method_call, result)).unwrap();
-    })));
 
     let size = window.size();
     tx_output_height.send(size.h).unwrap();
@@ -211,11 +194,6 @@ pub fn run_x11_client() {
     ]);
 
     let mut baton = None;
-
-    let gles_renderer = unsafe { GlesRenderer::new(egl_context) }.expect("Failed to initialize GLES");
-
-    state.gles_renderer = Some(gles_renderer);
-    state.gl = Some(Gles2::load_with(|s| unsafe { egl::get_proc_address(s) } as *const _));
 
     event_loop
         .handle()
@@ -238,7 +216,7 @@ pub fn run_x11_client() {
                 data.state.flutter_engine().send_window_metrics((size.w as u32, size.h as u32).into()).unwrap();
             }
             X11Event::PresentCompleted { .. } | X11Event::Refresh { .. } => {
-                data.state.is_next_vblank_scheduled = false;
+                data.state.is_next_flutter_frame_scheduled = false;
                 if let Some(baton) = data.baton.take() {
                     data.state.flutter_engine().on_vsync(baton).unwrap();
                 }
@@ -255,7 +233,7 @@ pub fn run_x11_client() {
         .expect("Failed to insert X11 Backend into event loop");
 
     event_loop.handle().insert_source(rx_baton, move |baton, _, data| {
-        if let Event::Msg(baton) = baton {
+        if let Msg(baton) = baton {
             data.baton = Some(baton);
         }
         if data.state.is_next_vblank_scheduled {
@@ -264,11 +242,6 @@ pub fn run_x11_client() {
         if let Some(baton) = data.baton.take() {
             data.state.flutter_engine().on_vsync(baton).unwrap();
         }
-
-        // if let Err(err) = data.state.backend_data.x11_surface.submit() {
-        //     data.state.backend_data.x11_surface.reset_buffers();
-        //     warn!("Failed to submit buffer: {}. Retrying", err);
-        // };
     }).unwrap();
 
     event_loop.handle().insert_source(rx_request_fbo, move |_, _, data| {
@@ -289,20 +262,6 @@ pub fn run_x11_client() {
             data.state.backend_data.x11_surface.reset_buffers();
             warn!("Failed to submit buffer: {}. Retrying", err);
         };
-    }).unwrap();
-
-    event_loop.handle().insert_source(rx_request_external_texture_name, move |event, _, data| {
-        if let Msg(texture_id) = event {
-            let texture_swap_chain = data.state.texture_swapchains.get_mut(&texture_id);
-            let texture_id = match texture_swap_chain {
-                Some(texture) => {
-                    let texture = texture.start_read();
-                    texture.tex_id()
-                }
-                None => 0,
-            };
-            let _ = tx_external_texture_name.send((texture_id, RGBA8));
-        }
     }).unwrap();
 
     while state.running.load(Ordering::SeqCst) {


### PR DESCRIPTION
- The DRM backend works again, the compositor can be started from a TTY.
- Some code between the X11 and DRM backends has been unified to avoid duplication.
- All platform channel method handlers have been moved to `src/flutter_engine/platform_channel_callbacks.rs`.
- Fix a bug where the Flutter engine would hang waiting for an external texture id and the compositor would never shut down.