### PR TITLE
Implement window move and resize

### DIFF
--- a/embedder/src/drm_backend.rs
+++ b/embedder/src/drm_backend.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::mem::MaybeUninit;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 

--- a/embedder/src/flutter_engine/callbacks.rs
+++ b/embedder/src/flutter_engine/callbacks.rs
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn platform_message_callback<BackendData>(message: *const 
 {
     let flutter_engine = &mut *(user_data as *mut FlutterEngine<BackendData>);
     let message = &*message;
-    flutter_engine.binary_messenger.as_mut().unwrap().handle_message(message);
+    flutter_engine.binary_messenger.borrow_mut().handle_message(message);
 }
 
 pub unsafe extern "C" fn gl_external_texture_frame_callback<BackendData>(


### PR DESCRIPTION
There were already some memory leaks around texture handling, and if you resize a window too much, there will be Wayland protocol errors. I will fix all the leaks in the next PR.

An instance of the platform channel is now stored in FlutterEngine. It didn't make sense to create a new instance every time you wanted to send a message through the channel.
The binary messenger had to be put under reference count because it was impossible to store the platform channel having a non-owning reference to the binary messenger.

Changed some Option\<T\> fields to T inside FlutterEngine. These fields are never supposed to be None, but I had to make them optional because I needed to separate allocation and initialization. With the help of MaybeUninit, I could change them to T, which makes it more ergonomic not having to call `.as_ref().unwrap()` all the time.

Ergonomic problems around Option\<T\> also exist in ServerState because some fields should never be optional.
I will figure out how to fix that issue in a later PR because the problem is slightly different and the same fix cannot be applied.